### PR TITLE
java-11-support-fix: Add missing dependency

### DIFF
--- a/impc_prod_tracker/pom.xml
+++ b/impc_prod_tracker/pom.xml
@@ -26,6 +26,10 @@
     		<version>0.9.1</version>
 		</dependency>
 		<dependency>
+			<groupId>javax.xml.bind</groupId>
+			<artifactId>jaxb-api</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-security</artifactId>
 		</dependency>


### PR DESCRIPTION
* Add the jaxb-api dependency that needs to be explicity added after java 9.