### PR TITLE
jpa-error-management: Add exception handling support to provide unifi…

### DIFF
--- a/impc_prod_tracker/pom.xml
+++ b/impc_prod_tracker/pom.xml
@@ -26,10 +26,6 @@
     		<version>0.9.1</version>
 		</dependency>
 		<dependency>
-			<groupId>javax.xml.bind</groupId>
-			<artifactId>jaxb-api</artifactId>
-		</dependency>
-		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-security</artifactId>
 		</dependency>
@@ -57,6 +53,11 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-jpa</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>com.fasterxml.jackson.datatype</groupId>
+			<artifactId>jackson-datatype-jsr310</artifactId>
 		</dependency>
 
 		<!-- https://mvnrepository.com/artifact/org.postgresql/postgresql -->

--- a/impc_prod_tracker/src/main/java/uk/ac/ebi/impc_prod_tracker/conf/exeption_management/ApiException.java
+++ b/impc_prod_tracker/src/main/java/uk/ac/ebi/impc_prod_tracker/conf/exeption_management/ApiException.java
@@ -1,0 +1,179 @@
+/*******************************************************************************
+ * Copyright 2019 EMBL - European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ *******************************************************************************/
+package uk.ac.ebi.impc_prod_tracker.conf.exeption_management;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.annotation.JsonTypeIdResolver;
+import com.fasterxml.jackson.databind.jsontype.impl.TypeIdResolverBase;
+import lombok.Data;
+import org.hibernate.validator.internal.engine.path.PathImpl;
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.FieldError;
+import org.springframework.validation.ObjectError;
+import javax.validation.ConstraintViolation;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Class to keep detailed information of exceptions raised in the application.
+ * Taken from https://github.com/brunocleite/spring-boot-exception-handling.
+ */
+@Data
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonTypeInfo(
+    include = JsonTypeInfo.As.WRAPPER_OBJECT, use = JsonTypeInfo.Id.CUSTOM, property = "error", visible = true)
+@JsonTypeIdResolver(LowerCaseClassNameResolver.class)
+public class ApiException
+{
+    private HttpStatus status;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "dd-MM-yyyy hh:mm:ss")
+    private LocalDateTime timestamp;
+    private String message;
+    private String debugMessage;
+    private List<ApiSubException> subErrors;
+
+    private ApiException()
+    {
+        timestamp = LocalDateTime.now();
+    }
+
+    public ApiException(HttpStatus status)
+    {
+        this();
+        this.status = status;
+    }
+
+    public ApiException(HttpStatus status, Throwable ex)
+    {
+        this();
+        this.status = status;
+        this.message = "Unexpected error";
+        this.debugMessage = ex.getLocalizedMessage();
+    }
+
+    public ApiException(HttpStatus status, String message, Throwable ex)
+    {
+        this();
+        this.status = status;
+        this.message = message;
+        this.debugMessage = ex.getLocalizedMessage();
+    }
+
+    public ApiException(HttpStatus status, String message, String debugMessage)
+    {
+        this();
+        this.status = status;
+        this.message = message;
+        this.debugMessage = debugMessage;
+    }
+
+    public ApiException(HttpStatus status, ExceptionFormatter exceptionFormatter)
+    {
+        this();
+        this.status = status;
+        this.message = exceptionFormatter.getMessage();
+        this.debugMessage = exceptionFormatter.getDebugMessage();
+    }
+
+    private void addSubError(ApiSubException subError)
+    {
+        if (subErrors == null)
+        {
+            subErrors = new ArrayList<>();
+        }
+        subErrors.add(subError);
+    }
+
+    private void addValidationError(String object, String field, Object rejectedValue, String message)
+    {
+        addSubError(new ApiValidationException(object, field, rejectedValue, message));
+    }
+
+    private void addValidationError(String object, String message)
+    {
+        addSubError(new ApiValidationException(object, message));
+    }
+
+    private void addValidationError(FieldError fieldError)
+    {
+        this.addValidationError(
+            fieldError.getObjectName(),
+            fieldError.getField(),
+            fieldError.getRejectedValue(),
+            fieldError.getDefaultMessage());
+    }
+
+    void addValidationErrors(List<FieldError> fieldErrors)
+    {
+        fieldErrors.forEach(this::addValidationError);
+    }
+
+    private void addValidationError(ObjectError objectError)
+    {
+        this.addValidationError(
+            objectError.getObjectName(),
+            objectError.getDefaultMessage());
+    }
+
+    void addValidationError(List<ObjectError> globalErrors)
+    {
+        globalErrors.forEach(this::addValidationError);
+    }
+
+    /**
+     * Utility method for adding error of ConstraintViolation. Usually when a @Validated validation fails.
+     *
+     * @param cv the ConstraintViolation
+     */
+    private void addValidationError(ConstraintViolation<?> cv)
+    {
+        this.addValidationError(
+            cv.getRootBeanClass().getSimpleName(),
+            ((PathImpl) cv.getPropertyPath()).getLeafNode().asString(),
+            cv.getInvalidValue(),
+            cv.getMessage());
+    }
+
+    void addValidationErrors(Set<ConstraintViolation<?>> constraintViolations)
+    {
+        constraintViolations.forEach(this::addValidationError);
+    }
+}
+
+class LowerCaseClassNameResolver extends TypeIdResolverBase
+{
+    @Override
+    public String idFromValue(Object value)
+    {
+        return value.getClass().getSimpleName().toLowerCase();
+    }
+
+    @Override
+    public String idFromValueAndType(Object value, Class<?> suggestedType)
+    {
+        return idFromValue(value);
+    }
+
+    @Override
+    public JsonTypeInfo.Id getMechanism()
+    {
+        return JsonTypeInfo.Id.CUSTOM;
+    }
+}

--- a/impc_prod_tracker/src/main/java/uk/ac/ebi/impc_prod_tracker/conf/exeption_management/ApiSubException.java
+++ b/impc_prod_tracker/src/main/java/uk/ac/ebi/impc_prod_tracker/conf/exeption_management/ApiSubException.java
@@ -13,26 +13,12 @@
  * language governing permissions and limitations under the
  * License.
  *******************************************************************************/
-package uk.ac.ebi.impc_prod_tracker.conf.security;
-
-import uk.ac.ebi.impc_prod_tracker.data.organization.role.Role;
-import uk.ac.ebi.impc_prod_tracker.data.organization.work_unit.WorkUnit;
+package uk.ac.ebi.impc_prod_tracker.conf.exeption_management;
 
 /**
- * Information a subject in the system should have.
- * @author Mauricio Martinez
+ * Class to keep information to errors that will be grouped in a parent object.
+ * Taken from https://github.com/brunocleite/spring-boot-exception-handling.
  */
-public interface SystemSubject
+abstract class ApiSubException
 {
-    String getLogin();
-
-    String getName();
-
-    String getUserRefId();
-
-    String getEmail();
-
-    Role getRole();
-
-    WorkUnit getWorkUnit();
 }

--- a/impc_prod_tracker/src/main/java/uk/ac/ebi/impc_prod_tracker/conf/exeption_management/ApiValidationException.java
+++ b/impc_prod_tracker/src/main/java/uk/ac/ebi/impc_prod_tracker/conf/exeption_management/ApiValidationException.java
@@ -13,26 +13,29 @@
  * language governing permissions and limitations under the
  * License.
  *******************************************************************************/
-package uk.ac.ebi.impc_prod_tracker.conf.security;
+package uk.ac.ebi.impc_prod_tracker.conf.exeption_management;
 
-import uk.ac.ebi.impc_prod_tracker.data.organization.role.Role;
-import uk.ac.ebi.impc_prod_tracker.data.organization.work_unit.WorkUnit;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 /**
- * Information a subject in the system should have.
- * @author Mauricio Martinez
+ * Class to keep details for Validation Errors.
+ * Taken from https://github.com/brunocleite/spring-boot-exception-handling.
  */
-public interface SystemSubject
+@Data
+@EqualsAndHashCode(callSuper = false)
+@AllArgsConstructor
+public class ApiValidationException extends ApiSubException
 {
-    String getLogin();
+    private String object;
+    private String field;
+    private Object rejectedValue;
+    private String message;
 
-    String getName();
-
-    String getUserRefId();
-
-    String getEmail();
-
-    Role getRole();
-
-    WorkUnit getWorkUnit();
+    ApiValidationException(String object, String message)
+    {
+        this.object = object;
+        this.message = message;
+    }
 }

--- a/impc_prod_tracker/src/main/java/uk/ac/ebi/impc_prod_tracker/conf/exeption_management/BaseExceptionFormatter.java
+++ b/impc_prod_tracker/src/main/java/uk/ac/ebi/impc_prod_tracker/conf/exeption_management/BaseExceptionFormatter.java
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ * Copyright 2019 EMBL - European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ *******************************************************************************/
+package uk.ac.ebi.impc_prod_tracker.conf.exeption_management;
+
+import lombok.Data;
+import lombok.NonNull;
+
+/**
+ * Class to format an exception and get a suitable message and debugMessage values.
+ */
+@Data
+public abstract class BaseExceptionFormatter implements ExceptionFormatter
+{
+    protected String message;
+    protected String debugMessage;
+    @NonNull
+    protected Throwable exception;
+
+    public BaseExceptionFormatter(Throwable exception)
+    {
+        this.exception = exception;
+        message = exception.getMessage();
+        debugMessage = null;
+    }
+
+    protected String formatString(String text)
+    {
+        String result;
+        if (text == null)
+        {
+            result = null;
+        }
+        else
+        {
+            result = text.replaceAll("\n", "").trim();
+            if (!result.endsWith("."))
+            {
+                result += ".";
+            }
+        }
+        return result;
+    }
+
+    public String getMessage()
+    {
+        return formatString(message);
+    }
+
+    public String getDebugMessage()
+    {
+        return formatString(debugMessage);
+    }
+}

--- a/impc_prod_tracker/src/main/java/uk/ac/ebi/impc_prod_tracker/conf/exeption_management/ExceptionFormatter.java
+++ b/impc_prod_tracker/src/main/java/uk/ac/ebi/impc_prod_tracker/conf/exeption_management/ExceptionFormatter.java
@@ -13,26 +13,23 @@
  * language governing permissions and limitations under the
  * License.
  *******************************************************************************/
-package uk.ac.ebi.impc_prod_tracker.conf.security;
-
-import uk.ac.ebi.impc_prod_tracker.data.organization.role.Role;
-import uk.ac.ebi.impc_prod_tracker.data.organization.work_unit.WorkUnit;
+package uk.ac.ebi.impc_prod_tracker.conf.exeption_management;
 
 /**
- * Information a subject in the system should have.
- * @author Mauricio Martinez
+ * Classes implementing this interface should receive an exception and provide an error and debug message from it,
+ * ignoring unnecessary details.
  */
-public interface SystemSubject
+public interface ExceptionFormatter
 {
-    String getLogin();
+    /**
+     * Gets a formatted exception message.
+     * @return String with formatted exception message.
+     */
+    String getMessage();
 
-    String getName();
-
-    String getUserRefId();
-
-    String getEmail();
-
-    Role getRole();
-
-    WorkUnit getWorkUnit();
+    /**
+     * Gets a formatted exception debug message.
+     * @return String with formatted exception debug message.
+     */
+    String getDebugMessage();
 }

--- a/impc_prod_tracker/src/main/java/uk/ac/ebi/impc_prod_tracker/conf/exeption_management/ExceptionHandlerFilter.java
+++ b/impc_prod_tracker/src/main/java/uk/ac/ebi/impc_prod_tracker/conf/exeption_management/ExceptionHandlerFilter.java
@@ -1,0 +1,99 @@
+/*******************************************************************************
+ * Copyright 2019 EMBL - European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ *******************************************************************************/
+package uk.ac.ebi.impc_prod_tracker.conf.exeption_management;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+import javax.servlet.FilterChain;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+/**
+ * This class controls exceptions that occur before even calling controllers, that is, catches exceptions that
+ * are not managed by {@link RestExceptionHandler}.
+ */
+
+@Component
+public class ExceptionHandlerFilter extends OncePerRequestFilter
+{
+    private ObjectMapper mapper = new ObjectMapper();
+    public ExceptionHandlerFilter()
+    {
+        mapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
+        mapper.registerModule(new JavaTimeModule());
+    }
+
+    @Override
+    public void doFilterInternal(
+        HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+    throws IOException
+    {
+        ApiException apiException;
+        try
+        {
+            filterChain.doFilter(request, response);
+        }
+        catch (OperationFailedException ofe)
+        {
+            apiException = new ApiException(HttpStatus.INTERNAL_SERVER_ERROR, ofe.getMessage(), ofe.getDebugMessage());
+            addExceptionInfoToResponse(response, apiException);
+        }
+        catch (RuntimeException e)
+        {
+            apiException = new ApiException(HttpStatus.INTERNAL_SERVER_ERROR, e.getMessage(), e);
+            addExceptionInfoToResponse(response, apiException);
+        }
+        catch (Exception e)
+        {
+            if (e.getCause() instanceof OperationFailedException)
+            {
+                OperationFailedException ofe = (OperationFailedException) e.getCause();
+                apiException =
+                    new ApiException(HttpStatus.INTERNAL_SERVER_ERROR, ofe.getMessage(), ofe.getDebugMessage());
+            }
+            else
+            {
+                apiException = new ApiException(HttpStatus.INTERNAL_SERVER_ERROR, e.getMessage(), "");
+            }
+            addExceptionInfoToResponse(response, apiException);
+        }
+    }
+
+    private void addExceptionInfoToResponse(HttpServletResponse response, ApiException apiException)
+    throws IOException
+    {
+        response.setStatus(apiException.getStatus().value());
+        response.setContentType(MediaType.APPLICATION_JSON.toString());
+        response.getWriter().write(convertObjectToJson(apiException));
+    }
+
+    public String convertObjectToJson(Object object)
+    throws JsonProcessingException
+    {
+        if (object == null)
+        {
+            return null;
+        }
+        return mapper.writeValueAsString(object);
+    }
+}

--- a/impc_prod_tracker/src/main/java/uk/ac/ebi/impc_prod_tracker/conf/exeption_management/JsonPayloadExceptionFormatter.java
+++ b/impc_prod_tracker/src/main/java/uk/ac/ebi/impc_prod_tracker/conf/exeption_management/JsonPayloadExceptionFormatter.java
@@ -1,0 +1,82 @@
+/*******************************************************************************
+ * Copyright 2019 EMBL - European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ *******************************************************************************/
+package uk.ac.ebi.impc_prod_tracker.conf.exeption_management;
+
+import com.fasterxml.jackson.core.JsonParseException;
+
+/**
+ * Class to format Json related exceptions.
+ */
+public class JsonPayloadExceptionFormatter extends BaseExceptionFormatter
+{
+
+    private static final String UNRECOGNIZED_TOKEN = "Unrecognized token";
+    private static final String UNEXPECTED_CHARACTER = "Unexpected character";
+    private static final String PARSE_ERROR_END = ": was expecting";
+    private static final String MESSAGE = "The Json could not be parsed.";
+    private static final String DEBUG_MESSAGE = "Please verify that the values that are string are not lacking " +
+        "quotation marks, and that the numeric fields have valid values.";
+
+    public JsonPayloadExceptionFormatter(Throwable exception)
+    {
+        super(exception);
+        init();
+    }
+
+    private void init()
+    {
+        String rootCauseMessage = exception.getMessage();
+        if (exception instanceof JsonParseException)
+        {
+            message = MESSAGE;
+            if (rootCauseMessage.contains(UNRECOGNIZED_TOKEN))
+            {
+                processJsonParseExceptionByUnrecognizedToken(rootCauseMessage);
+            }
+            else if (rootCauseMessage.contains(UNEXPECTED_CHARACTER))
+            {
+                processJsonParseExceptionByUnexpectedCharacter(rootCauseMessage);
+            }
+        }
+    }
+
+    /**
+     * Formats a message that looks like:
+     * com.fasterxml.jackson.core.JsonParseException: Unrecognized token 'sa': was expecting ('true', 'false' or 'null')
+     *  at [Source: (org.apache.catalina.connector.CoyoteInputStream);
+     * @param completeMessage The exception message.
+     */
+    private void processJsonParseExceptionByUnrecognizedToken(String completeMessage)
+    {
+        int indexInit = completeMessage.indexOf(UNRECOGNIZED_TOKEN);
+        int indexEnd = completeMessage.indexOf(PARSE_ERROR_END);
+        debugMessage = completeMessage.substring(indexInit, indexEnd) + ". " + DEBUG_MESSAGE;
+    }
+
+    /**
+     * Formats a message that looks like:
+     * com.fasterxml.jackson.core.JsonParseException:Unexpected character ('5' (code 53)): was expecting
+     *  double-quote to start field name
+     *  at [Source: (org.apache.catalina.connector.CoyoteInputStream); line: 4, column: 13]
+     * @param completeMessage The exception message.
+     */
+    private void processJsonParseExceptionByUnexpectedCharacter(String completeMessage)
+    {
+        int indexInit = completeMessage.indexOf(UNEXPECTED_CHARACTER);
+        int indexEnd = completeMessage.indexOf(PARSE_ERROR_END);
+        debugMessage = completeMessage.substring(indexInit, indexEnd) + ". " + DEBUG_MESSAGE;
+    }
+}

--- a/impc_prod_tracker/src/main/java/uk/ac/ebi/impc_prod_tracker/conf/exeption_management/OperationFailedException.java
+++ b/impc_prod_tracker/src/main/java/uk/ac/ebi/impc_prod_tracker/conf/exeption_management/OperationFailedException.java
@@ -13,18 +13,36 @@
  * language governing permissions and limitations under the
  * License.
  *******************************************************************************/
-package uk.ac.ebi.impc_prod_tracker.conf.security.jwt;
+package uk.ac.ebi.impc_prod_tracker.conf.exeption_management;
 
-import org.springframework.security.core.AuthenticationException;
+import lombok.Getter;
 
 /**
- * Exception for invalid JWT.
+ * Class to manage the Exceptions in the application
+ *
  * @author Mauricio Martinez
  */
-public class InvalidJwtAuthenticationException extends AuthenticationException
+@Getter
+public class OperationFailedException extends RuntimeException
 {
-    public InvalidJwtAuthenticationException(String e)
+    private String debugMessage;
+    private Throwable cause;
+
+    public OperationFailedException(String message)
     {
-        super(e);
+        super(message);
+    }
+
+    public OperationFailedException(String message, Throwable cause)
+    {
+        this(message);
+        this.cause = cause;
+        this.debugMessage = cause.getLocalizedMessage();
+    }
+
+    public OperationFailedException(String message, String debugMessage)
+    {
+        this(message);
+        this.debugMessage = debugMessage;
     }
 }

--- a/impc_prod_tracker/src/main/java/uk/ac/ebi/impc_prod_tracker/conf/exeption_management/RestExceptionHandler.java
+++ b/impc_prod_tracker/src/main/java/uk/ac/ebi/impc_prod_tracker/conf/exeption_management/RestExceptionHandler.java
@@ -1,0 +1,287 @@
+/*******************************************************************************
+ * Copyright 2019 EMBL - European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ *******************************************************************************/
+package uk.ac.ebi.impc_prod_tracker.conf.exeption_management;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.http.converter.HttpMessageNotWritableException;
+import org.springframework.transaction.TransactionSystemException;
+import org.springframework.web.HttpMediaTypeNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.context.request.ServletWebRequest;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.servlet.NoHandlerFoundException;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+import javax.persistence.EntityNotFoundException;
+import javax.validation.ConstraintViolationException;
+
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+
+/**
+ * Central Exception handling. Taken from https://github.com/brunocleite/spring-boot-exception-handling.
+ */
+@Order(Ordered.HIGHEST_PRECEDENCE)
+@ControllerAdvice
+@Slf4j
+public class RestExceptionHandler extends ResponseEntityExceptionHandler
+{
+    /**
+     * Handle MissingServletRequestParameterException. Triggered when a 'required' request parameter is missing.
+     *
+     * @param ex      MissingServletRequestParameterException
+     * @param headers HttpHeaders
+     * @param status  HttpStatus
+     * @param request WebRequest
+     * @return the ApiException object
+     */
+    @Override
+    protected ResponseEntity<Object> handleMissingServletRequestParameter(
+        MissingServletRequestParameterException ex,
+        HttpHeaders headers,
+        HttpStatus status,
+        WebRequest request)
+    {
+        String error = ex.getParameterName() + " parameter is missing";
+        return buildResponseEntity(new ApiException(BAD_REQUEST, error, ex));
+    }
+
+
+    /**
+     * Handle HttpMediaTypeNotSupportedException. This one triggers when JSON is invalid as well.
+     *
+     * @param ex      HttpMediaTypeNotSupportedException
+     * @param headers HttpHeaders
+     * @param status  HttpStatus
+     * @param request WebRequest
+     * @return the ApiException object
+     */
+    @Override
+    protected ResponseEntity<Object> handleHttpMediaTypeNotSupported(
+        HttpMediaTypeNotSupportedException ex,
+        HttpHeaders headers,
+        HttpStatus status,
+        WebRequest request)
+    {
+        StringBuilder builder = new StringBuilder();
+        builder.append(ex.getContentType());
+        builder.append(" media type is not supported. Supported media types are ");
+        ex.getSupportedMediaTypes().forEach(t -> builder.append(t).append(", "));
+        return buildResponseEntity(
+            new ApiException(
+                HttpStatus.UNSUPPORTED_MEDIA_TYPE, builder.substring(0, builder.length() - 2), ex));
+    }
+
+    /**
+     * Handle MethodArgumentNotValidException. Triggered when an object fails @Valid validation.
+     *
+     * @param ex      the MethodArgumentNotValidException that is thrown when @Valid validation fails
+     * @param headers HttpHeaders
+     * @param status  HttpStatus
+     * @param request WebRequest
+     * @return the ApiException object
+     */
+    @Override
+    protected ResponseEntity<Object> handleMethodArgumentNotValid(
+        MethodArgumentNotValidException ex,
+        HttpHeaders headers,
+        HttpStatus status,
+        WebRequest request)
+    {
+        ApiException apiException = new ApiException(BAD_REQUEST);
+        apiException.setMessage("Validation error");
+        apiException.addValidationErrors(ex.getBindingResult().getFieldErrors());
+        apiException.addValidationError(ex.getBindingResult().getGlobalErrors());
+
+        return buildResponseEntity(apiException);
+    }
+
+    /**
+     * Handles javax.validation.ConstraintViolationException. Thrown when @Validated fails.
+     *
+     * @param ex the ConstraintViolationException
+     * @return the ApiException object
+     */
+    @ExceptionHandler(ConstraintViolationException.class)
+    protected ResponseEntity<Object> handleConstraintViolation(
+        ConstraintViolationException ex) {
+        ApiException apiException = new ApiException(BAD_REQUEST);
+        apiException.setMessage("Validation error");
+        apiException.addValidationErrors(ex.getConstraintViolations());
+        return buildResponseEntity(apiException);
+    }
+
+    @ExceptionHandler(TransactionSystemException.class)
+    protected ResponseEntity<Object> handleConstraintViolation(
+    TransactionSystemException ex)
+    {
+        ApiException apiException = new ApiException(BAD_REQUEST);
+        apiException.setMessage("Validation error");
+
+        if (ex.getOriginalException().getCause() instanceof ConstraintViolationException)
+        {
+            ConstraintViolationException constraintViolationException =
+                (ConstraintViolationException)ex.getOriginalException().getCause();
+            apiException.addValidationErrors(constraintViolationException.getConstraintViolations());
+        }
+        return buildResponseEntity(apiException);
+    }
+
+    /**
+     * Handles EntityNotFoundException. Created to encapsulate errors with more detail than
+     * javax.persistence.EntityNotFoundException.
+     *
+     * @param ex the EntityNotFoundException
+     * @return the ApiException object
+     */
+    @ExceptionHandler(EntityNotFoundException.class)
+    protected ResponseEntity<Object> handleEntityNotFound(
+        EntityNotFoundException ex) {
+        ApiException apiException = new ApiException(NOT_FOUND);
+        apiException.setMessage(ex.getMessage());
+        return buildResponseEntity(apiException);
+    }
+
+    /**
+     * Handle HttpMessageNotReadableException. Happens when request JSON is malformed.
+     *
+     * @param ex      HttpMessageNotReadableException
+     * @param headers HttpHeaders
+     * @param status  HttpStatus
+     * @param request WebRequest
+     * @return the ApiException object
+     */
+    @Override
+    protected ResponseEntity<Object> handleHttpMessageNotReadable(
+        HttpMessageNotReadableException ex,
+        HttpHeaders headers,
+        HttpStatus status,
+        WebRequest request)
+    {
+        ServletWebRequest servletWebRequest = (ServletWebRequest) request;
+        log.info("{} to {}", servletWebRequest.getHttpMethod(), servletWebRequest.getRequest().getServletPath());
+        ApiException apiException = null;
+        String error = "Malformed JSON request";
+        if (ex.getCause() instanceof JsonParseException)
+        {
+            apiException = new ApiException(BAD_REQUEST, new JsonPayloadExceptionFormatter(ex.getCause()));
+        }
+        else
+        {
+            apiException = new ApiException(BAD_REQUEST, error, ex);
+        }
+        return buildResponseEntity(apiException);
+    }
+
+    /**
+     * Handle HttpMessageNotWritableException.
+     *
+     * @param ex      HttpMessageNotWritableException
+     * @param headers HttpHeaders
+     * @param status  HttpStatus
+     * @param request WebRequest
+     * @return the ApiException object
+     */
+    @Override
+    protected ResponseEntity<Object> handleHttpMessageNotWritable(
+        HttpMessageNotWritableException ex, HttpHeaders headers, HttpStatus status, WebRequest request)
+    {
+        String error = "Error writing JSON output";
+        return buildResponseEntity(new ApiException(HttpStatus.INTERNAL_SERVER_ERROR, error, ex));
+    }
+
+    /**
+     * Handle NoHandlerFoundException.
+     *
+     * @param ex      HttpMessageNotWritableException
+     * @param headers HttpHeaders
+     * @param status  HttpStatus
+     * @param request WebRequest
+     * @return the ApiException object
+     */
+    @Override
+    protected ResponseEntity<Object> handleNoHandlerFoundException(
+        NoHandlerFoundException ex, HttpHeaders headers, HttpStatus status, WebRequest request)
+    {
+        ApiException apiException = new ApiException(BAD_REQUEST);
+        apiException.setMessage(
+            String.format("Could not find the %s method for URL %s", ex.getHttpMethod(), ex.getRequestURL()));
+        apiException.setDebugMessage(ex.getMessage());
+        return buildResponseEntity(apiException);
+    }
+
+    /**
+     * Handle DataIntegrityViolationException, inspects the cause for different DB causes.
+     *
+     * @param ex the DataIntegrityViolationException
+     * @return the ApiException object
+     */
+    @ExceptionHandler(DataIntegrityViolationException.class)
+    protected ResponseEntity<Object> handleDataIntegrityViolation(
+        DataIntegrityViolationException ex, WebRequest request)
+    {
+        ResponseEntity<Object> responseEntity = null;
+        if (ex.getCause() instanceof ConstraintViolationException)
+        {
+            responseEntity =
+                buildResponseEntity(new ApiException(HttpStatus.CONFLICT, "Database error", ex.getCause()));
+        }
+        else if(ex.getCause() instanceof org.hibernate.exception.ConstraintViolationException)
+        {
+            responseEntity =
+                buildResponseEntity(
+                    new ApiException(HttpStatus.CONFLICT, new SqlExceptionFormatter(ex)));
+        }
+        return responseEntity;
+    }
+
+    /**
+     * Handle Exception, handle generic Exception.class.
+     *
+     * @param ex the Exception.
+     * @return the ApiException object.
+     */
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    protected ResponseEntity<Object> handleMethodArgumentTypeMismatch(
+        MethodArgumentTypeMismatchException ex,WebRequest request)
+    {
+        ApiException apiException = new ApiException(BAD_REQUEST);
+        apiException.setMessage(
+            String.format(
+                "The parameter '%s' of value '%s' could not be converted to type '%s'",
+                ex.getName(),
+                ex.getValue(),
+                ex.getRequiredType().getSimpleName()));
+        apiException.setDebugMessage(ex.getMessage());
+        return buildResponseEntity(apiException);
+    }
+
+    private ResponseEntity<Object> buildResponseEntity(ApiException apiException)
+    {
+        return new ResponseEntity<>(apiException, apiException.getStatus());
+    }
+}

--- a/impc_prod_tracker/src/main/java/uk/ac/ebi/impc_prod_tracker/conf/exeption_management/SqlExceptionFormatter.java
+++ b/impc_prod_tracker/src/main/java/uk/ac/ebi/impc_prod_tracker/conf/exeption_management/SqlExceptionFormatter.java
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ * Copyright 2019 EMBL - European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ *******************************************************************************/
+package uk.ac.ebi.impc_prod_tracker.conf.exeption_management;
+
+import org.springframework.dao.DataIntegrityViolationException;
+
+public class SqlExceptionFormatter extends BaseExceptionFormatter
+{
+    private static final String UNIQUE_CONSTRAINT_MESSAGE = "duplicate key value violates unique constraint";
+
+    public SqlExceptionFormatter(Throwable exception)
+    {
+        super(exception);
+        init();
+    }
+
+    private void init()
+    {
+        String rootCauseMessage = exception.getMessage();
+        if (exception instanceof org.springframework.dao.DataIntegrityViolationException)
+        {
+            rootCauseMessage = ((DataIntegrityViolationException) exception).getRootCause().getMessage();
+            if (rootCauseMessage.contains(UNIQUE_CONSTRAINT_MESSAGE))
+            {
+                processDuplicateKeyException(rootCauseMessage);
+            }
+        }
+        message = formatString(message);
+        debugMessage = formatString(debugMessage);
+    }
+
+    /**
+     * Method expecting an error like this:
+     * ERROR: duplicate key value violates unique constraint "uk_2r45e34u6qbbksaobuopx32kh"
+     *   Detail: Key (code)=(Code1) already exists.
+     *   The message is of course jpa implementation (hibernate) specific, so this method will change if
+     *   another implementation is chosen (or if hibernate changes the error message).
+     * @param rootCauseMessage The complete exception message that contains all needed details.
+     */
+   private void processDuplicateKeyException(String rootCauseMessage)
+    {
+        int initIndex = rootCauseMessage.indexOf("Detail:");
+        message = rootCauseMessage.substring(initIndex);
+        debugMessage = rootCauseMessage.substring(0, initIndex - 1);
+    }
+}

--- a/impc_prod_tracker/src/main/java/uk/ac/ebi/impc_prod_tracker/conf/security/RootConfiguration.java
+++ b/impc_prod_tracker/src/main/java/uk/ac/ebi/impc_prod_tracker/conf/security/RootConfiguration.java
@@ -23,7 +23,9 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import uk.ac.ebi.impc_prod_tracker.conf.exeption_management.ExceptionHandlerFilter;
 import uk.ac.ebi.impc_prod_tracker.conf.security.jwt.JwtTokenFilter;
 
 /**
@@ -33,23 +35,30 @@ import uk.ac.ebi.impc_prod_tracker.conf.security.jwt.JwtTokenFilter;
  */
 @Configuration
 @EnableWebSecurity
-//@EnableJpaAuditing(auditorAwareRef = "auditorProvider")
 @EnableJpaAuditing
 public class RootConfiguration extends WebSecurityConfigurerAdapter
 {
     private JwtTokenFilter jwtTokenFilter;
+    private ExceptionHandlerFilter exceptionHandlerFilter;
 
-    public RootConfiguration(JwtTokenFilter jwtTokenFilter)
+
+    public RootConfiguration(
+        JwtTokenFilter jwtTokenFilter, ExceptionHandlerFilter exceptionHandlerFilter)
     {
         this.jwtTokenFilter = jwtTokenFilter;
+        this.exceptionHandlerFilter = exceptionHandlerFilter;
+
     }
 
     @Bean
     @Override
-    public AuthenticationManager authenticationManagerBean()
-    throws Exception
-    {
-        return super.authenticationManagerBean();
+    protected AuthenticationManager authenticationManager() throws Exception {
+        return super.authenticationManager();
+    }
+
+    @Bean
+    public BCryptPasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
     }
 
     @Override
@@ -67,6 +76,7 @@ public class RootConfiguration extends WebSecurityConfigurerAdapter
             .anyRequest().authenticated()
             .and()
             .addFilterBefore(jwtTokenFilter, UsernamePasswordAuthenticationFilter.class)
+            .addFilterBefore(exceptionHandlerFilter, JwtTokenFilter.class)
         ;
     }
 }

--- a/impc_prod_tracker/src/main/java/uk/ac/ebi/impc_prod_tracker/conf/security/jwt/JwtTokenFilter.java
+++ b/impc_prod_tracker/src/main/java/uk/ac/ebi/impc_prod_tracker/conf/security/jwt/JwtTokenFilter.java
@@ -42,7 +42,7 @@ public class JwtTokenFilter extends GenericFilterBean
 
     @Override
     public void doFilter(ServletRequest req, ServletResponse res, FilterChain filterChain)
-        throws IOException, ServletException
+    throws IOException, ServletException
     {
         String token = jwtTokenProvider.resolveToken((HttpServletRequest) req);
         if (token != null && jwtTokenProvider.validateToken(token))

--- a/impc_prod_tracker/src/main/java/uk/ac/ebi/impc_prod_tracker/conf/security/jwt/JwtTokenProvider.java
+++ b/impc_prod_tracker/src/main/java/uk/ac/ebi/impc_prod_tracker/conf/security/jwt/JwtTokenProvider.java
@@ -25,6 +25,7 @@ import io.jsonwebtoken.SigningKeyResolverAdapter;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
+import uk.ac.ebi.impc_prod_tracker.conf.exeption_management.OperationFailedException;
 import uk.ac.ebi.impc_prod_tracker.conf.security.AapSystemSubject;
 import uk.ac.ebi.impc_prod_tracker.conf.security.PublicKeyProvider;
 import uk.ac.ebi.impc_prod_tracker.conf.security.SystemSubject;
@@ -42,6 +43,11 @@ public class JwtTokenProvider
 {
     private static final String AUTHORIZATION_HEADER = "Authorization";
     private static final String AUTHORIZATION_SCHEMA_NAME = "Bearer ";
+    private static final String INVALID_TOKEN_MESSAGE = "Expired or invalid JWT token.";
+    private static final String INVALID_TOKEN_DEBUG_MESSAGE =
+        "Tokens expire after a while (usually 1 hour), please create a new one. Also check that you are using the " +
+            "whole token in the authentication header. Contact your administrator if after checking this " +
+            "you keep receiving the same error.";
 
     private PublicKeyProvider publicKeyProvider;
     private AapSystemSubject aapSystemSubject;
@@ -108,7 +114,7 @@ public class JwtTokenProvider
         }
         catch (JwtException | IllegalArgumentException e)
         {
-            throw new InvalidJwtAuthenticationException("Expired or invalid JWT token");
+            throw new OperationFailedException(INVALID_TOKEN_MESSAGE, INVALID_TOKEN_DEBUG_MESSAGE);
         }
     }
 

--- a/impc_prod_tracker/src/main/java/uk/ac/ebi/impc_prod_tracker/controller/AuthController.java
+++ b/impc_prod_tracker/src/main/java/uk/ac/ebi/impc_prod_tracker/controller/AuthController.java
@@ -16,13 +16,12 @@
 package uk.ac.ebi.impc_prod_tracker.controller;
 
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.authentication.AuthenticationManager;
-import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import uk.ac.ebi.impc_prod_tracker.conf.exeption_management.OperationFailedException;
 import uk.ac.ebi.impc_prod_tracker.domain.login.AuthenticationRequest;
 import uk.ac.ebi.impc_prod_tracker.service.AuthService;
 import java.util.HashMap;
@@ -39,12 +38,11 @@ import static org.springframework.http.ResponseEntity.ok;
 @RequestMapping("/auth")
 public class AuthController
 {
-    private AuthenticationManager authenticationManager;
+    private static final String AUTHENTICATION_ERROR = "Invalid User/Password provided.";
     private AuthService authService;
 
-    public AuthController(AuthenticationManager authenticationManager, AuthService authService)
+    public AuthController( AuthService authService)
     {
-        this.authenticationManager = authenticationManager;
         this.authService = authService;
     }
 
@@ -69,7 +67,7 @@ public class AuthController
         }
         catch (AuthenticationException e)
         {
-            throw new BadCredentialsException("Invalid username/password supplied");
+            throw new OperationFailedException(AUTHENTICATION_ERROR);
         }
     }
 }

--- a/impc_prod_tracker/src/main/java/uk/ac/ebi/impc_prod_tracker/data/organization/person/PersonRepository.java
+++ b/impc_prod_tracker/src/main/java/uk/ac/ebi/impc_prod_tracker/data/organization/person/PersonRepository.java
@@ -18,4 +18,5 @@ package uk.ac.ebi.impc_prod_tracker.data.organization.person;
 import org.springframework.data.repository.CrudRepository;
 
 public interface PersonRepository extends CrudRepository<Person, Long> {
+    Person findPersonByAuthIdEquals(String authId);
 }

--- a/impc_prod_tracker/src/main/resources/application-dev.properties
+++ b/impc_prod_tracker/src/main/resources/application-dev.properties
@@ -11,3 +11,10 @@ spring.jpa.properties.hibernate.jdbc.lob.non_contextual_creation=true
 
 # Hibernate ddl auto (create, create-drop, validate, update)
 spring.jpa.hibernate.ddl-auto = update
+
+#show sql statement
+logging.level.org.hibernate.SQL=debug
+
+#show sql values
+logging.level.org.hibernate.type.descriptor.sql=trace
+spring.main.web-environment-type=none


### PR DESCRIPTION
…ed errors in the API responses.

* Add the class ApiException which provides information about the exception, with a suitable detail level.
* Add OperationFailedException class which can be used to describe a general exception in the application. It allows to have a general error message and a debug error message. This class avoids the creation of individual exception classes.
* Add several classes to format the exception messages allowing to process them and giving the user a more useful and clearer message.
* Add ExceptionHandlerFilter.java to handle all filter related errors in the application.
* Add RestExceptionHandler to handle the errors risen while calling the REST end-points.