### PR TITLE
Allows to have an PlanDetailsDTO without pin or privacyName

### DIFF
--- a/impc_prod_tracker/src/main/java/uk/ac/ebi/impc_prod_tracker/controller/project/plan/PlanDetailsDTO.java
+++ b/impc_prod_tracker/src/main/java/uk/ac/ebi/impc_prod_tracker/controller/project/plan/PlanDetailsDTO.java
@@ -17,16 +17,13 @@ package uk.ac.ebi.impc_prod_tracker.controller.project.plan;
 
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
 
 @Data
-@RequiredArgsConstructor
 @NoArgsConstructor
 public class PlanDetailsDTO
 {
-    @NonNull private String pin;
-    @NonNull private String privacyName;
+    private String pin;
+    private String privacyName;
     private String planTypeName;
     private String consortiumName;
     private String workUnitName;


### PR DESCRIPTION
* In some cases pin and privacyName are not mandatory (for example when using the DTO in an update payload) so the restriction is removed.