### PR TITLE
Update logic to give access to a project

### DIFF
--- a/impc_prod_tracker/src/main/java/uk/ac/ebi/impc_prod_tracker/data/organization/work_unit/WorkUnit.java
+++ b/impc_prod_tracker/src/main/java/uk/ac/ebi/impc_prod_tracker/data/organization/work_unit/WorkUnit.java
@@ -15,13 +15,10 @@
  *******************************************************************************/
 package uk.ac.ebi.impc_prod_tracker.data.organization.work_unit;
 
-import com.fasterxml.jackson.annotation.JsonBackReference;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.*;
 import uk.ac.ebi.impc_prod_tracker.data.BaseEntity;
 import uk.ac.ebi.impc_prod_tracker.data.organization.consortium.Consortium;
-import uk.ac.ebi.impc_prod_tracker.data.organization.funder.Funder;
-import uk.ac.ebi.impc_prod_tracker.data.organization.institute.Institute;
 import uk.ac.ebi.impc_prod_tracker.data.organization.work_group.WorkGroup;
 
 import javax.persistence.*;
@@ -30,7 +27,6 @@ import java.util.Set;
 @NoArgsConstructor(access= AccessLevel.PRIVATE, force=true)
 @Data
 @Entity
-//@EqualsAndHashCode( exclude = {"workGroups"}, callSuper = false)
 public class WorkUnit extends BaseEntity
 {
     @Id

--- a/impc_prod_tracker/src/main/java/uk/ac/ebi/impc_prod_tracker/service/WorkUnitService.java
+++ b/impc_prod_tracker/src/main/java/uk/ac/ebi/impc_prod_tracker/service/WorkUnitService.java
@@ -1,10 +1,20 @@
 package uk.ac.ebi.impc_prod_tracker.service;
 
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import uk.ac.ebi.impc_prod_tracker.data.organization.consortium.Consortium;
+import uk.ac.ebi.impc_prod_tracker.data.organization.consortium.Consortium_;
 import uk.ac.ebi.impc_prod_tracker.data.organization.work_group.WorkGroup;
 import uk.ac.ebi.impc_prod_tracker.data.organization.work_unit.WorkUnit;
 import uk.ac.ebi.impc_prod_tracker.data.organization.work_unit.WorkUnitRepository;
+import uk.ac.ebi.impc_prod_tracker.data.organization.work_unit.WorkUnit_;
 
+import javax.persistence.EntityManager;
+import javax.persistence.NoResultException;
+import javax.persistence.PersistenceContext;
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Root;
 import java.util.List;
 import java.util.Set;
 
@@ -12,6 +22,8 @@ import java.util.Set;
 public class WorkUnitService {
 
     private WorkUnitRepository workUnitRepository;
+    @PersistenceContext
+    private EntityManager entityManager;
 
     public WorkUnitService(WorkUnitRepository workUnitRepository){
         this.workUnitRepository = workUnitRepository;
@@ -26,6 +38,28 @@ public class WorkUnitService {
 
         }
         return null;
+    }
+
+    @Transactional
+    public WorkUnit getWorkUnitWithConsortia(Long id)
+    {
+        CriteriaBuilder cb = entityManager.getCriteriaBuilder();
+        CriteriaQuery<WorkUnit> query = cb.createQuery(WorkUnit.class);
+        Root<WorkUnit> root = query.from(WorkUnit.class);
+        query.select(root);
+        root.fetch(WorkUnit_.consortia);
+        query.where(cb.equal(root.get("id"), id));
+        WorkUnit workUnit = null;
+        try
+        {
+            workUnit = entityManager.createQuery(query).getSingleResult();
+        }
+        catch (NoResultException nre)
+        {
+
+        }
+
+        return workUnit;
     }
 
 }

--- a/impc_prod_tracker/src/main/resources/uk/ac/ebi/impc_prod_tracker/conf/security/abac/policy/json/default-policy.json
+++ b/impc_prod_tracker/src/main/resources/uk/ac/ebi/impc_prod_tracker/conf/security/abac/policy/json/default-policy.json
@@ -55,13 +55,13 @@
   },
   {
     "name": "Read public projects.",
-    "description": "A user can read a project that is public.",
+    "description": "A project that is public can be read by anyone.",
     "target": "action == 'READ_PROJECT'",
     "condition": "resource.resourcePrivacy.name() == 'PUBLIC'"
   },
   {
     "name": "Read projects in related consortia.",
-    "description": "A user can read a project that is related with consortia where the user is a member.",
+    "description": "A user can read a project that is related to a consortium where the user is a member of that consortium.",
     "target": "action == 'READ_PROJECT'",
     "condition": "subject.belongsToConsortia(resource.consortia)"
   }


### PR DESCRIPTION
* The access to read project is given if the user belongs to the projects consortia or if they belong to a work unit that is related with the projects consortia.
* Created getWorkUnitWithConsortia in WorkUnitService to retrieve a workUnit with consortia without getting LazyInitialization error.