### PR TITLE
Updating projects and plans endpoints

### DIFF
--- a/impc_prod_tracker/src/main/java/uk/ac/ebi/impc_prod_tracker/data/biology/project/Project.java
+++ b/impc_prod_tracker/src/main/java/uk/ac/ebi/impc_prod_tracker/data/biology/project/Project.java
@@ -52,7 +52,7 @@ public class Project extends BaseEntity implements Resource<Project>
 
     @EqualsAndHashCode.Exclude
     @ToString.Exclude
-    @OneToMany
+    @OneToMany(fetch=FetchType.EAGER)
     @JoinColumn(name = "project_id")
     private Set<AssignmentStatusStamp> assignmentStatusStamps;
 

--- a/impc_prod_tracker/src/main/java/uk/ac/ebi/impc_prod_tracker/service/plan/PlanService.java
+++ b/impc_prod_tracker/src/main/java/uk/ac/ebi/impc_prod_tracker/service/plan/PlanService.java
@@ -26,6 +26,8 @@ import java.util.List;
 
 public interface PlanService
 {
+    Page<Plan> getPlans(Pageable pageable, List<String> tpns, List<String> workUnitNames);
+
     Plan getPlanByPinWithoutCheckPermissions(String pin);
 
     /**

--- a/impc_prod_tracker/src/main/java/uk/ac/ebi/impc_prod_tracker/service/plan/PlanServiceImpl.java
+++ b/impc_prod_tracker/src/main/java/uk/ac/ebi/impc_prod_tracker/service/plan/PlanServiceImpl.java
@@ -25,12 +25,11 @@ import uk.ac.ebi.impc_prod_tracker.conf.security.abac.ResourceAccessChecker;
 import uk.ac.ebi.impc_prod_tracker.data.biology.plan_outcome.PlanOutcomeRepository;
 import uk.ac.ebi.impc_prod_tracker.data.biology.plan.Plan;
 import uk.ac.ebi.impc_prod_tracker.data.biology.plan.PlanRepository;
-import uk.ac.ebi.impc_prod_tracker.data.biology.project.Project;
 import uk.ac.ebi.impc_prod_tracker.data.common.history.History;
 import uk.ac.ebi.impc_prod_tracker.service.plan.engine.PlanUpdater;
 import uk.ac.ebi.impc_prod_tracker.service.plan.engine.UpdatePlanRequestProcessor;
 import uk.ac.ebi.impc_prod_tracker.web.dto.plan.PlanDTO;
-import java.util.ArrayList;
+
 import java.util.List;
 
 @Component
@@ -62,6 +61,24 @@ public class PlanServiceImpl implements PlanService
         this.planOutcomeRepository = planOutcomeRepository;
         this.historyService = historyService;
     }
+
+    @Override
+    public Page<Plan> getPlans(Pageable pageable, List<String> tpns, List<String> workUnitNames)
+    {
+        Specification<Plan> specifications =
+            buildSpecificationsWithCriteria(tpns, workUnitNames);
+        return planRepository.findAll(specifications, pageable);
+    }
+
+    private Specification<Plan> buildSpecificationsWithCriteria(
+        List<String> tpns, List<String> workUnitNames)
+    {
+        Specification<Plan> specifications =
+            Specification.where(PlanSpecs.withTpns(tpns))
+                .and(Specification.where(PlanSpecs.withWorkUnitNames(workUnitNames)));
+        return specifications;
+    }
+
 
     @Override
     //TODO

--- a/impc_prod_tracker/src/main/java/uk/ac/ebi/impc_prod_tracker/service/plan/PlanSpecs.java
+++ b/impc_prod_tracker/src/main/java/uk/ac/ebi/impc_prod_tracker/service/plan/PlanSpecs.java
@@ -1,0 +1,75 @@
+package uk.ac.ebi.impc_prod_tracker.service.plan;
+
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.stereotype.Component;
+import uk.ac.ebi.impc_prod_tracker.data.biology.plan.Plan;
+import uk.ac.ebi.impc_prod_tracker.data.biology.plan.Plan_;
+import uk.ac.ebi.impc_prod_tracker.data.biology.project.Project;
+import uk.ac.ebi.impc_prod_tracker.data.biology.project.Project_;
+import uk.ac.ebi.impc_prod_tracker.data.organization.work_unit.WorkUnit;
+import uk.ac.ebi.impc_prod_tracker.data.organization.work_unit.WorkUnit_;
+import javax.persistence.criteria.Path;
+import javax.persistence.criteria.Predicate;
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+public class PlanSpecs
+{
+    /**
+     * Get all the projects which plans are related with the work units specified in workUnitNames
+     * @param workUnitNames List of names of the Work Units
+     * @return The found projects. If workUnitNames is null then not filter is applied.
+     */
+    public static Specification<Plan> withWorkUnitNames(List<String> workUnitNames)
+    {
+        Specification<Plan> specification;
+        if (workUnitNames == null)
+        {
+            specification = buildTrueCondition();
+        }
+        else
+        {
+            specification = (Specification<Plan>) (root, query, criteriaBuilder) ->
+            {
+                List<Predicate> predicates = new ArrayList<>();
+                Path<WorkUnit> workUnitPath = root.get(Plan_.workUnit);
+                Path<String> workUnitName = workUnitPath.get(WorkUnit_.name);
+                predicates.add(workUnitName.in(workUnitNames));
+                query.distinct(true);
+                return criteriaBuilder.and(predicates.toArray(new Predicate[predicates.size()]));
+            };
+
+        }
+        return specification;
+    }
+
+    public static Specification<Plan> withTpns(List<String> tpns)
+    {
+        Specification<Plan> specification;
+        if (tpns == null)
+        {
+            specification = buildTrueCondition();
+        }
+        else
+        {
+            specification = (Specification<Plan>) (root, query, criteriaBuilder) ->
+            {
+                List<Predicate> predicates = new ArrayList<>();
+                Path<Project> projectPath = root.get(Plan_.project);
+                Path<String> tpnPath = projectPath.get(Project_.tpn);
+                predicates.add(tpnPath.in(tpns));
+                query.distinct(true);
+                return criteriaBuilder.and(predicates.toArray(new Predicate[predicates.size()]));
+            };
+
+        }
+        return specification;
+    }
+
+    private static Specification<Plan> buildTrueCondition()
+    {
+        return (Specification<Plan>) (root, query, criteriaBuilder) ->
+            criteriaBuilder.isTrue(criteriaBuilder.literal(true));
+    }
+}

--- a/impc_prod_tracker/src/main/java/uk/ac/ebi/impc_prod_tracker/service/project/ProjectService.java
+++ b/impc_prod_tracker/src/main/java/uk/ac/ebi/impc_prod_tracker/service/project/ProjectService.java
@@ -24,29 +24,11 @@ import java.util.List;
 
 public interface ProjectService
 {
-    /**
-     * Get all the projects that a user has access to. The visibility of a project is given by the
-     * existence of at least one plan in the project that has a work unit that matches with the
-     * user's work unit.
-     * @param pageable Pageable information.
-     * @param consortiaNames Optional list of consortia names to filter the results.
-     *                       If null no filters are applied.
-     * @param statusesNames Optional list of statuses names to filter the results.
-     *                      If null no filters are applied.
-     * @param privaciesNames Optional list of privacies names to filter the results.
-     *                       If null no filters are applied.
-     * @return Paginated projects.
-     */
-    Page<Project> getCurrentUserProjects(
-        Pageable pageable,
-        List<String> consortiaNames,
-        List<String> statusesNames,
-        List<String> privaciesNames);
-
-    Project getCurrentUserProjectByTpn(String tpn);
+    Project getProjectByTpn(String tpn);
 
     Page<Project> getProjects(
         Pageable pageable,
+        List<String> workUnitNames,
         List<String> consortiaNames,
         List<String> statusesNames,
         List<String> privaciesNames);

--- a/impc_prod_tracker/src/main/java/uk/ac/ebi/impc_prod_tracker/service/project/ProjectSpecs.java
+++ b/impc_prod_tracker/src/main/java/uk/ac/ebi/impc_prod_tracker/service/project/ProjectSpecs.java
@@ -13,32 +13,28 @@
  * language governing permissions and limitations under the
  * License.
  *******************************************************************************/
-package uk.ac.ebi.impc_prod_tracker.web.controller.project;
+package uk.ac.ebi.impc_prod_tracker.service.project;
 
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Component;
-import uk.ac.ebi.impc_prod_tracker.conf.security.abac.spring.SubjectRetriever;
 import uk.ac.ebi.impc_prod_tracker.data.biology.assignment_status.AssignmentStatus;
 import uk.ac.ebi.impc_prod_tracker.data.biology.assignment_status.AssignmentStatus_;
 import uk.ac.ebi.impc_prod_tracker.data.biology.plan.Plan;
 import uk.ac.ebi.impc_prod_tracker.data.biology.plan.Plan_;
-import uk.ac.ebi.impc_prod_tracker.data.biology.plan.type.PlanType;
-import uk.ac.ebi.impc_prod_tracker.data.biology.plan.type.PlanType_;
 import uk.ac.ebi.impc_prod_tracker.data.biology.privacy.Privacy;
 import uk.ac.ebi.impc_prod_tracker.data.biology.privacy.Privacy_;
 import uk.ac.ebi.impc_prod_tracker.data.biology.project.Project;
 import uk.ac.ebi.impc_prod_tracker.data.biology.project.Project_;
 import uk.ac.ebi.impc_prod_tracker.data.organization.consortium.Consortium;
 import uk.ac.ebi.impc_prod_tracker.data.organization.consortium.Consortium_;
-import uk.ac.ebi.impc_prod_tracker.data.organization.person_role_work_unit.PersonRoleWorkUnit;
 import uk.ac.ebi.impc_prod_tracker.data.organization.work_unit.WorkUnit;
 import uk.ac.ebi.impc_prod_tracker.data.organization.work_unit.WorkUnit_;
+
 import javax.persistence.criteria.Path;
 import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.SetJoin;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * This class creates the filters needed when searching projects.
@@ -46,78 +42,18 @@ import java.util.stream.Collectors;
 @Component
 public class ProjectSpecs
 {
-    private SubjectRetriever subjectRetriever;
-
-    public ProjectSpecs(SubjectRetriever subjectRetriever)
-    {
-        this.subjectRetriever = subjectRetriever;
-    }
-
-    public Specification<Project> withPlansInUserWorkUnits()
-    {
-        Specification<Project> specification;
-
-        if (subjectRetriever.getSubject().isAdmin())
-        {
-            specification = (Specification<Project>) (root, query, criteriaBuilder)
-                -> criteriaBuilder.isTrue(criteriaBuilder.literal(true));
-        }
-        else
-        {
-            List<WorkUnit> workUnits =
-                subjectRetriever.getSubject().getRoleWorkUnits().stream()
-                    .map(PersonRoleWorkUnit::getWorkUnit)
-                    .collect(Collectors.toList());
-            List<String> workUnitNames = new ArrayList<>();
-            workUnits.forEach(x -> workUnitNames.add(x.getName()));
-            if (workUnits.isEmpty())
-            {
-                specification = (Specification<Project>) (root, query, criteriaBuilder)
-                    -> criteriaBuilder.isTrue(criteriaBuilder.literal(false));
-            }
-            else
-            {
-                specification = getProjectsByWorkUnitNames(workUnitNames);
-            }
-        }
-        return specification;
-    }
-
-    /**
-     * Get all the projects which plans are related with the work units specified in workUnitNames
-     * @param workUnitNames List of names of the Work Units
-     * @return The found projects. If workUnitNames is null then not filter is applied.
-     */
-    private static Specification<Project> getProjectsByWorkUnitNames(List<String> workUnitNames)
-    {
-        return (Specification<Project>) (root, query, criteriaBuilder) -> {
-            if (workUnitNames == null)
-            {
-                return criteriaBuilder.isTrue(criteriaBuilder.literal(true));
-            }
-
-            List<Predicate> predicates = new ArrayList<>();
-
-            SetJoin<Project, Plan> plansJoin = root.join(Project_.plans);
-            Path<WorkUnit> workUnitPath = plansJoin.get(Plan_.workUnit);
-            Path<String> workUnitName = workUnitPath.get(WorkUnit_.name);
-            predicates.add(workUnitName.in(workUnitNames));
-            query.distinct(true);
-
-            return criteriaBuilder.and(predicates.toArray(new Predicate[predicates.size()]));
-        };
-    }
-
     /**
      * Get all the projects which related genes have the marker symbols defined in parameter
      * markerSymbols.
+     *
      * @param markerSymbols List of names of the marker symbols
      * @return The found projects. If markerSymbols is null then not filter is applied.
      */
     public static Specification<Project> getProjectsByMarkerSymbolAndSpecie(List<String> markerSymbols)
     {
         return (Specification<Project>) (root, query, criteriaBuilder) -> {
-            if (markerSymbols == null) {
+            if (markerSymbols == null)
+            {
                 return criteriaBuilder.isTrue(criteriaBuilder.literal(true));
             }
 
@@ -137,70 +73,51 @@ public class ProjectSpecs
     }
 
     /**
-     * Get all the projects which plans are related with the work units specified in workGroupNames
-     * @param workGroupsNames List of names of Work Group
-     * @return The found projects. If markerSymbols is null then not filter is applied.
+     * Get all the projects which plans are related with the work units specified in workUnitNames
+     * @param workUnitNames List of names of the Work Units
+     * @return The found projects. If workUnitNames is null then not filter is applied.
      */
-    public static Specification<Project> getProjectsByWorkGroup(List<String> workGroupsNames)
+    public static Specification<Project> withPlansInWorkUnitsNames(List<String> workUnitNames)
     {
-        return (Specification<Project>) (root, query, criteriaBuilder) -> {
-            if (workGroupsNames == null)
-            {
-                return criteriaBuilder.isTrue(criteriaBuilder.literal(true));
-            }
+        Specification<Project> specification;
 
-            List<Predicate> predicates = new ArrayList<>();
+        if (workUnitNames == null)
+        {
+            specification = buildTrueCondition();
+        }
+        else
+        {
+            specification = (Specification<Project>) (root, query, criteriaBuilder) -> {
 
-            SetJoin<Project, Plan> plansJoin = root.join(Project_.plans);
-            //TODO: Filter at project level
-//            Path<WorkGroup> workGroupPath = plansJoin.get(Plan_.workGroup);
-//            Path<String> workGroupName = workGroupPath.get(WorkGroup_.name);
-//            predicates.add(workGroupName.in(workGroupsNames));
-            query.distinct(true);
+                List<Predicate> predicates = new ArrayList<>();
 
-            return criteriaBuilder.and(predicates.toArray(new Predicate[predicates.size()]));
-        };
-    }
+                SetJoin<Project, Plan> plansJoin = root.join(Project_.plans);
+                Path<WorkUnit> workUnitPath = plansJoin.get(Plan_.workUnit);
+                Path<String> workUnitName = workUnitPath.get(WorkUnit_.name);
+                predicates.add(workUnitName.in(workUnitNames));
+                query.distinct(true);
 
-    /**
-     * Get all the projects which plans of the specified type in planTypes.
-     * @param planTypes List of plan types.
-     * @return The found projects. If planTypes is null then not filter is applied.
-     */
-    public static Specification<Project> getProjectsByPlanType(List<String> planTypes)
-    {
-        return (Specification<Project>) (root, query, criteriaBuilder) -> {
-            if (planTypes == null)
-            {
-                return criteriaBuilder.isTrue(criteriaBuilder.literal(true));
-            }
+                return criteriaBuilder.and(predicates.toArray(new Predicate[predicates.size()]));
+            };
+        }
+        return specification;
 
-            List<Predicate> predicates = new ArrayList<>();
-
-            SetJoin<Project, Plan> plansJoin = root.join(Project_.plans);
-            Path<PlanType> planType = plansJoin.get(Plan_.planType);
-            Path<String> planTypeName = planType.get(PlanType_.name);
-            predicates.add(planTypeName.in(planTypes));
-            query.distinct(true);
-
-            return criteriaBuilder.and(predicates.toArray(new Predicate[predicates.size()]));
-        };
     }
 
     /**
      * Get all the projects whose status is one of the list of statuses provided.
+     *
      * @param statuses List of names of statuses.
      * @return The found projects. If statuses is null then not filter is applied.
      */
-    public Specification<Project> withStatuses(List<String> statuses)
+    public static Specification<Project> withStatuses(List<String> statuses)
     {
         Specification<Project> specification;
         if (statuses == null)
         {
             specification = (Specification<Project>) (root, query, criteriaBuilder) ->
                 criteriaBuilder.isTrue(criteriaBuilder.literal(true));
-        }
-        else
+        } else
         {
             specification = (Specification<Project>) (root, query, criteriaBuilder) -> {
 
@@ -219,18 +136,18 @@ public class ProjectSpecs
 
     /**
      * Get all the projects with a specific privacy (or privacies).
+     *
      * @param privacies List of names of privacies.
      * @return The found projects. If privacies is null then not filter is applied.
      */
-    public Specification<Project> withPrivacies(List<String> privacies)
+    public static Specification<Project> withPrivacies(List<String> privacies)
     {
         Specification<Project> specification;
         if (privacies == null)
         {
             specification = (Specification<Project>) (root, query, criteriaBuilder) ->
                 criteriaBuilder.isTrue(criteriaBuilder.literal(true));
-        }
-        else
+        } else
         {
             specification = (Specification<Project>) (root, query, criteriaBuilder) -> {
 
@@ -249,18 +166,18 @@ public class ProjectSpecs
 
     /**
      * Get all the projects with a specific consortium (or consortia).
+     *
      * @param consortia List of names of consortia.
      * @return The found projects. If privacies is null then not filter is applied.
      */
-    public Specification<Project> withConsortia(List<String> consortia)
+    public static Specification<Project> withConsortia(List<String> consortia)
     {
         Specification<Project> specification;
         if (consortia == null)
         {
             specification = (Specification<Project>) (root, query, criteriaBuilder) ->
                 criteriaBuilder.isTrue(criteriaBuilder.literal(true));
-        }
-        else
+        } else
         {
             specification = (Specification<Project>) (root, query, criteriaBuilder) -> {
 
@@ -279,18 +196,18 @@ public class ProjectSpecs
 
     /**
      * Get all the projects with a specific tpn (or tpns).
+     *
      * @param tpns List of names of tpn.
      * @return The found projects. If tpn is null then not filter is applied.
      */
-    public Specification<Project> withTpns(List<String> tpns)
+    public static Specification<Project> withTpns(List<String> tpns)
     {
         Specification<Project> specification;
         if (tpns == null)
         {
             specification = (Specification<Project>) (root, query, criteriaBuilder) ->
                 criteriaBuilder.isTrue(criteriaBuilder.literal(true));
-        }
-        else
+        } else
         {
             specification = (Specification<Project>) (root, query, criteriaBuilder) -> {
 
@@ -303,5 +220,11 @@ public class ProjectSpecs
             };
         }
         return specification;
+    }
+
+    private static Specification<Project> buildTrueCondition()
+    {
+        return (Specification<Project>) (root, query, criteriaBuilder) ->
+            criteriaBuilder.isTrue(criteriaBuilder.literal(true));
     }
 }

--- a/impc_prod_tracker/src/main/java/uk/ac/ebi/impc_prod_tracker/web/controller/plan/PlanController.java
+++ b/impc_prod_tracker/src/main/java/uk/ac/ebi/impc_prod_tracker/web/controller/plan/PlanController.java
@@ -15,21 +15,29 @@
  *******************************************************************************/
 package uk.ac.ebi.impc_prod_tracker.web.controller.plan;
 
-import org.springframework.hateoas.server.ExposesResourceFor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PagedResourcesAssembler;
+import org.springframework.hateoas.PagedModel;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import uk.ac.ebi.impc_prod_tracker.data.biology.plan.Plan;
 import uk.ac.ebi.impc_prod_tracker.data.common.history.History;
 import uk.ac.ebi.impc_prod_tracker.service.plan.PlanService;
+import uk.ac.ebi.impc_prod_tracker.web.controller.util.LinkUtil;
 import uk.ac.ebi.impc_prod_tracker.web.dto.common.history.HistoryDTO;
 import uk.ac.ebi.impc_prod_tracker.web.dto.plan.PlanDTO;
 import uk.ac.ebi.impc_prod_tracker.web.mapping.common.history.HistoryMapper;
 import uk.ac.ebi.impc_prod_tracker.web.mapping.plan.PlanMapper;
 import java.util.List;
 
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
+
 @RestController
 @RequestMapping("/api/plans")
 @CrossOrigin(origins="*")
-@ExposesResourceFor(PlanDTO.class)
 public class PlanController
 {
     private HistoryMapper historyMapper;
@@ -43,8 +51,38 @@ public class PlanController
         this.planMapper = planMapper;
     }
 
+    @GetMapping
+    public ResponseEntity findAll(
+        Pageable pageable,
+        PagedResourcesAssembler assembler,
+        @RequestParam(value = "tpn", required = false) List<String> tpns,
+        @RequestParam(value = "work_unit_name", required = false) List<String> workUnitNames)
+    {
+        Page<Plan> plansPage = planService.getPlans(pageable, tpns, workUnitNames);
+        Page<PlanDTO> planDTOPage = plansPage.map(this::getDTO);
+        PagedModel pr =
+            assembler.toModel(
+                planDTOPage,
+                linkTo(PlanController.class).withSelfRel());
+
+        HttpHeaders responseHeaders = new HttpHeaders();
+        responseHeaders.add("Link", LinkUtil.createLinkHeader(pr));
+
+        return new ResponseEntity<>(pr, responseHeaders, HttpStatus.OK);
+    }
+
+    private PlanDTO getDTO(Plan plan)
+    {
+        PlanDTO planDTO = new PlanDTO();
+        if (plan != null)
+        {
+            planDTO = planMapper.toDto(plan);
+        }
+        return planDTO;
+    }
+
     @GetMapping(value = {"/{id}"})
-    public PlanDTO plan(@PathVariable("id") String pin)
+    public PlanDTO findOne(@PathVariable("id") String pin)
     {
         Plan plan = getNotNullPlanByPin(pin);
 
@@ -74,7 +112,7 @@ public class PlanController
         History history = planService.updatePlan(pin, planDTO);
         if (history != null)
         {
-            return  historyMapper.toDto(history);
+            return historyMapper.toDto(history);
         }
         return null;
     }

--- a/impc_prod_tracker/src/main/java/uk/ac/ebi/impc_prod_tracker/web/controller/project/ProjectController.java
+++ b/impc_prod_tracker/src/main/java/uk/ac/ebi/impc_prod_tracker/web/controller/project/ProjectController.java
@@ -70,14 +70,14 @@ class ProjectController
     public ResponseEntity findAll(
         Pageable pageable,
         PagedResourcesAssembler assembler,
+        @RequestParam(value = "work_unit_name", required = false) List<String> workUnitNames,
         @RequestParam(value = "consortium", required = false) List<String> consortia,
         @RequestParam(value = "status", required = false) List<String> statuses,
         @RequestParam(value = "privacy", required = false) List<String> privacies)
     {
         Page<Project> projects =
-            projectService.getProjects(pageable, consortia, statuses, privacies);
-        Page<ProjectDTO> projectDtos =
-            projects.map(this::getDTO);
+            projectService.getProjects(pageable, workUnitNames, consortia, statuses, privacies);
+        Page<ProjectDTO> projectDtos = projects.map(this::getDTO);
         PagedModel pr =
             assembler.toModel(
                 projectDtos,
@@ -112,7 +112,7 @@ class ProjectController
     public EntityModel<?> findOne(@PathVariable String tpn)
     {
         EntityModel<ProjectDTO> entityModel;
-        Project project = projectService.getCurrentUserProjectByTpn(tpn);
+        Project project = projectService.getProjectByTpn(tpn);
         ProjectDTO projectDTO = getDTO(project);
 
         if (projectDTO != null)

--- a/impc_prod_tracker/src/main/java/uk/ac/ebi/impc_prod_tracker/web/controller/project/ProjectUtilities.java
+++ b/impc_prod_tracker/src/main/java/uk/ac/ebi/impc_prod_tracker/web/controller/project/ProjectUtilities.java
@@ -19,7 +19,7 @@ public class ProjectUtilities
 
     public static Project getNotNullProjectByTpn(String tpn)
     {
-        Project project = projectService.getCurrentUserProjectByTpn(tpn);
+        Project project = projectService.getProjectByTpn(tpn);
         if (project == null)
         {
             throw new OperationFailedException(

--- a/impc_prod_tracker/src/main/java/uk/ac/ebi/impc_prod_tracker/web/dto/plan/PlanDTO.java
+++ b/impc_prod_tracker/src/main/java/uk/ac/ebi/impc_prod_tracker/web/dto/plan/PlanDTO.java
@@ -27,7 +27,6 @@ import uk.ac.ebi.impc_prod_tracker.web.dto.plan.phenotyping.PhenotypingAttemptDT
 import uk.ac.ebi.impc_prod_tracker.web.dto.plan.production.breeding_attempt.BreedingAttemptDTO;
 import uk.ac.ebi.impc_prod_tracker.web.dto.plan.production.crispr_attempt.CrisprAttemptDTO;
 import uk.ac.ebi.impc_prod_tracker.web.dto.status_stamps.StatusStampsDTO;
-
 import java.util.List;
 
 @Data
@@ -42,14 +41,11 @@ public class PlanDTO extends RepresentationModel
     private String pin;
 
     @NonNull
-    @JsonProperty("project_tpn")
+    @JsonProperty("tpn")
     private String tpn;
 
     @JsonProperty("funder_name")
     private String funderName;
-
-    @JsonProperty("consortium_name")
-    private String consortiumName;
 
     @JsonProperty("work_unit_name")
     private String workUnitName;

--- a/impc_prod_tracker/src/main/resources/application.properties
+++ b/impc_prod_tracker/src/main/resources/application.properties
@@ -4,3 +4,5 @@ local_authentication_url = https://explore.api.aai.ebi.ac.uk/auth
 spring.data.rest.base-path=/tracking-api
 
 spring.profiles.active=dev
+
+logging.level.web=debug


### PR DESCRIPTION
* Make /projects more generic so it brings all the projects that the user can see. Filters are provided for when it's called from the UI (filtering for specific work units, i.e).
* Add work_unit_name filter to /projects.
* Add tpn and work_unit_name filters to /plans.