### PR TITLE
Ignore invalid ids when receiving a Genotype Primers DTO.

### DIFF
--- a/impc_prod_tracker/src/main/java/uk/ac/ebi/impc_prod_tracker/data/biology/crispr_attempt/crispr_attempt_reagent/CrisprAttemptReagent.java
+++ b/impc_prod_tracker/src/main/java/uk/ac/ebi/impc_prod_tracker/data/biology/crispr_attempt/crispr_attempt_reagent/CrisprAttemptReagent.java
@@ -17,6 +17,7 @@ package uk.ac.ebi.impc_prod_tracker.data.biology.crispr_attempt.crispr_attempt_r
 
 import lombok.AccessLevel;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import uk.ac.ebi.impc_prod_tracker.data.BaseEntity;
 import uk.ac.ebi.impc_prod_tracker.data.biology.crispr_attempt.CrisprAttempt;
@@ -35,6 +36,7 @@ public class CrisprAttemptReagent extends BaseEntity
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "crisprAttemptReagentSeq")
     private Long id;
 
+    @EqualsAndHashCode.Exclude
     @NotNull
     @ManyToOne
     @JoinColumn(name = "attempt_id")

--- a/impc_prod_tracker/src/main/java/uk/ac/ebi/impc_prod_tracker/data/biology/crispr_attempt/guide/Guide.java
+++ b/impc_prod_tracker/src/main/java/uk/ac/ebi/impc_prod_tracker/data/biology/crispr_attempt/guide/Guide.java
@@ -19,16 +19,18 @@ import javax.persistence.SequenceGenerator;
 
 @NoArgsConstructor(access= AccessLevel.PUBLIC, force=true)
 @Data
-@EqualsAndHashCode( exclude = {"id", "crisprAttempt"}, callSuper = false)
+@EqualsAndHashCode(callSuper = false)
 @Entity
 public class Guide extends BaseEntity
 {
+    @EqualsAndHashCode.Exclude
     @Id
     @SequenceGenerator(name = "guideSeq", sequenceName = "GUIDE_SEQ")
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "guideSeq")
     private Long id;
 
     @JsonIgnore
+    @EqualsAndHashCode.Exclude
     @ManyToOne(targetEntity = CrisprAttempt.class)
     @JoinColumn(name = "attempt_id")
     private CrisprAttempt crisprAttempt;

--- a/impc_prod_tracker/src/main/java/uk/ac/ebi/impc_prod_tracker/data/biology/crispr_attempt/mutagenesis_donor/MutagenesisDonor.java
+++ b/impc_prod_tracker/src/main/java/uk/ac/ebi/impc_prod_tracker/data/biology/crispr_attempt/mutagenesis_donor/MutagenesisDonor.java
@@ -16,6 +16,7 @@ public class MutagenesisDonor extends BaseEntity
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "mutagenesisDonorSeq")
     private Long id;
 
+    @EqualsAndHashCode.Exclude
     @ManyToOne(targetEntity = CrisprAttempt.class)
     @JoinColumn(name = "attempt_id")
     private CrisprAttempt crisprAttempt;

--- a/impc_prod_tracker/src/main/java/uk/ac/ebi/impc_prod_tracker/data/biology/crispr_attempt/nuclease/Nuclease.java
+++ b/impc_prod_tracker/src/main/java/uk/ac/ebi/impc_prod_tracker/data/biology/crispr_attempt/nuclease/Nuclease.java
@@ -23,6 +23,7 @@ public class Nuclease extends BaseEntity
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "nucleaseSeq")
     private Long id;
 
+    @EqualsAndHashCode.Exclude
     @ManyToOne(targetEntity = CrisprAttempt.class)
     @JoinColumn(name = "attempt_id")
     private CrisprAttempt crisprAttempt;

--- a/impc_prod_tracker/src/main/java/uk/ac/ebi/impc_prod_tracker/web/dto/plan/production/crispr_attempt/MutagenesisDonorDTO.java
+++ b/impc_prod_tracker/src/main/java/uk/ac/ebi/impc_prod_tracker/web/dto/plan/production/crispr_attempt/MutagenesisDonorDTO.java
@@ -11,8 +11,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class MutagenesisDonorDTO
 {
-    @JsonIgnore
     private Long id;
+
     @JsonIgnore
     private Long attemptId;
 
@@ -20,8 +20,10 @@ public class MutagenesisDonorDTO
     private String vectorName;
 
     private Double concentration;
-    private String preparation;
+
+    @JsonProperty("preparation")
+    private String preparationTypeName;
 
     @JsonProperty("oligo_sequence_fa")
-    private String oligoSequenceFa;
+    private String oligoSequenceFasta;
 }

--- a/impc_prod_tracker/src/main/java/uk/ac/ebi/impc_prod_tracker/web/mapping/plan/attempt/crispr_attempt/GenotypePrimerMapper.java
+++ b/impc_prod_tracker/src/main/java/uk/ac/ebi/impc_prod_tracker/web/mapping/plan/attempt/crispr_attempt/GenotypePrimerMapper.java
@@ -31,11 +31,25 @@ public class GenotypePrimerMapper
 
     public GenotypePrimer toEntity(GenotypePrimerDTO genotypePrimerDTO)
     {
-        return entityMapper.toTarget(genotypePrimerDTO, GenotypePrimer.class);
+        GenotypePrimer genotypePrimer =
+            entityMapper.toTarget(genotypePrimerDTO, GenotypePrimer.class);
+        removeInvalidId(genotypePrimer);
+        return genotypePrimer;
     }
 
     public Set<GenotypePrimer> toEntities(Collection<GenotypePrimerDTO> genotypePrimerDTOS)
     {
-        return new HashSet<>(entityMapper.toTargets(genotypePrimerDTOS, GenotypePrimer.class));
+        Set<GenotypePrimer> genotypePrimers =
+            new HashSet<>(entityMapper.toTargets(genotypePrimerDTOS, GenotypePrimer.class));
+        genotypePrimers.forEach(this::removeInvalidId);
+        return genotypePrimers;
+    }
+
+    private void removeInvalidId(GenotypePrimer genotypePrimer)
+    {
+        if (genotypePrimer.getId() < 0)
+        {
+            genotypePrimer.setId(null);
+        }
     }
 }

--- a/impc_prod_tracker/src/test/java/uk/ac/ebi/impc_prod_tracker/web/mapping/plan/attempt/crispr_attempt/CrisprAttemptMapperTest.java
+++ b/impc_prod_tracker/src/test/java/uk/ac/ebi/impc_prod_tracker/web/mapping/plan/attempt/crispr_attempt/CrisprAttemptMapperTest.java
@@ -576,9 +576,9 @@ public class CrisprAttemptMapperTest
         MutagenesisDonorDTO mutagenesisDonorDTO = new MutagenesisDonorDTO();
         mutagenesisDonorDTO.setId(id);
         mutagenesisDonorDTO.setConcentration(MUTAGENESIS_DONOR_CONCENTRATION + id);
-        mutagenesisDonorDTO.setPreparation(MUTAGENESIS_DONOR_PREPARATION  + id);
+        mutagenesisDonorDTO.setPreparationTypeName(MUTAGENESIS_DONOR_PREPARATION  + id);
         mutagenesisDonorDTO.setVectorName(MUTAGENESIS_DONOR_VECTOR_NAME  + id);
-        mutagenesisDonorDTO.setOligoSequenceFa(MUTAGENESIS_DONOR_OLIGO_SEQUENCE_FA  + id);
+        mutagenesisDonorDTO.setOligoSequenceFasta(MUTAGENESIS_DONOR_OLIGO_SEQUENCE_FA  + id);
         return mutagenesisDonorDTO;
     }
 


### PR DESCRIPTION
* Includes also adjustments in some dtos fields and exclusion of fields for equals and hash in some methods.