### PR TITLE
Allow access without authentication to plans endpoint.

### DIFF
--- a/impc_prod_tracker/src/main/java/uk/ac/ebi/impc_prod_tracker/conf/security/RootConfiguration.java
+++ b/impc_prod_tracker/src/main/java/uk/ac/ebi/impc_prod_tracker/conf/security/RootConfiguration.java
@@ -82,7 +82,7 @@ public class RootConfiguration extends WebSecurityConfigurerAdapter
             .authorizeRequests()
             .antMatchers("/auth/signin").permitAll()
             .antMatchers("/api/conf").permitAll()
-            .antMatchers("/api/plans").permitAll()
+            .antMatchers("/api/plans/**").permitAll()
             .antMatchers("/api/projects/**").permitAll()
                 .antMatchers("/reports/**").permitAll()
                 .anyRequest().authenticated()

--- a/impc_prod_tracker/src/main/java/uk/ac/ebi/impc_prod_tracker/service/project/ProjectServiceImpl.java
+++ b/impc_prod_tracker/src/main/java/uk/ac/ebi/impc_prod_tracker/service/project/ProjectServiceImpl.java
@@ -78,16 +78,16 @@ public class ProjectServiceImpl implements ProjectService
           Specification<Project> specifications =
               buildSpecificationsWithCriteria(
                   workUnitNames, consortiaNames, statusesNames, privaciesNames);
-        Page<Project> projects = projectRepository.findAll(specifications, pageable);
+        List<Project> projects = projectRepository.findAll(specifications);
         return getAccessCheckedPage(projects, pageable);
     }
 
-    private Page<Project> getAccessCheckedPage(Page<Project> projects, Pageable pageable)
+    private Page<Project> getAccessCheckedPage(List<Project> projects, Pageable pageable)
     {
-        List<Project> filteredProjectList = getCheckedCollection(projects.getContent());
-        int numberElementsFilteredOut = projects.getContent().size() - filteredProjectList.size();
+
+        List<Project> filteredProjectList = getCheckedCollection(projects);
         return new PageImpl<>(
-            filteredProjectList, pageable, projects.getTotalElements() - numberElementsFilteredOut);
+            filteredProjectList, pageable, filteredProjectList.size());
     }
 
     private Project getAccessChecked(Project project)


### PR DESCRIPTION
* The access control for plans is in charge of ABAC, so is that mechanism the once that decides whether or not the view/read permissions are granted. Besides, plans can belong to public projects.