### PR TITLE
Fixing error while mapping assignment status from project to projectDto

### DIFF
--- a/impc_prod_tracker/src/main/java/uk/ac/ebi/impc_prod_tracker/data/biology/project/Project.java
+++ b/impc_prod_tracker/src/main/java/uk/ac/ebi/impc_prod_tracker/data/biology/project/Project.java
@@ -48,7 +48,6 @@ public class Project extends BaseEntity implements Resource<Project>
     private Long imitsMiPlanId;
 
     @EqualsAndHashCode.Exclude
-    @JsonIgnore
     @ToString.Exclude
     @ManyToOne
     private AssignmentStatus assignmentStatus;

--- a/impc_prod_tracker/src/main/java/uk/ac/ebi/impc_prod_tracker/web/dto/project/ProjectDTO.java
+++ b/impc_prod_tracker/src/main/java/uk/ac/ebi/impc_prod_tracker/web/dto/project/ProjectDTO.java
@@ -37,8 +37,7 @@ public class ProjectDTO extends RepresentationModel
     @NonNull
     private String tpn;
 
-    @NonNull
-    private String assigmentStatusName;
+    private String assignmentStatusName;
 
     @JsonProperty("assignmentStatusStamps")
     private List<StatusStampsDTO> statusStampsDTOS;


### PR DESCRIPTION
* There was a typo in the projectDto that prevented the right mapping of the assignmentStatusName field.