### PR TITLE
Adding Evo Inflector dependency to allow changing relation names.

### DIFF
--- a/impc_prod_tracker/pom.xml
+++ b/impc_prod_tracker/pom.xml
@@ -115,6 +115,13 @@
 			<version>2.3.2</version>
 		</dependency>
 
+        <!--Allow to change names in collections when mapping json-->
+		<dependency>
+			<groupId>org.atteo</groupId>
+			<artifactId>evo-inflector</artifactId>
+			<version>1.2.2</version>
+		</dependency>
+
 		<!--Jackson modules for date management.-->
 		<dependency>
 			<groupId>com.fasterxml.jackson.module</groupId>


### PR DESCRIPTION
Adding Evo Inflector dependency to allow changing relation names when mapping to json.

When working with hal embebed objects, the name of the root collections are built automatically and the name is not nice to show to the client (contains 'dtos' word, for instance). With Evo Inflector we can set a custom name for the collections.