### PR TITLE
Changed the Kubernetes ingress controller for the API server to work …

### DIFF
--- a/impc_prod_tracker/kube/sandbox/api-service/api-service-ingress.yaml
+++ b/impc_prod_tracker/kube/sandbox/api-service/api-service-ingress.yaml
@@ -26,7 +26,7 @@ metadata:
     # https://github.com/nginxinc/kubernetes-ingress/
     #
     kubernetes.io/ingress.class: nginx
-    nginx.ingress.kubernetes.io/rewrite-target: /$2
+    nginx.ingress.kubernetes.io/rewrite-target: /production-tracker-sandbox-api/$2
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
 
 spec:


### PR DESCRIPTION
…with the SERVER_SERVLET_CONTEXT_PATH defined in the deployment manifest. This preseves the context of the REST API base path when deployed on the Kubernetes cluster.