### PR TITLE
add the @AutoConfigureTestDatabase annotation

### DIFF
--- a/impc_prod_tracker/rest-api/src/test/java/org/gentar/WebApiApplicationTests.java
+++ b/impc_prod_tracker/rest-api/src/test/java/org/gentar/WebApiApplicationTests.java
@@ -1,11 +1,13 @@
 package org.gentar;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
 @ActiveProfiles("test")
+@AutoConfigureTestDatabase
 class WebApiApplicationTests {
 
 	@Test


### PR DESCRIPTION
add the @AutoConfigureTestDatabase annotation so that a unique embedded database is used for each test.

Ref https://stackoverflow.com/questions/47895212/spring-boot-2-h2-database-springboottest-failing-on-org-h2-jdbc-jdbcsqlex