### PR TITLE
Fixed null value for work unit in Tissue Distribution object

### DIFF
--- a/impc_prod_tracker/dto/src/main/java/org/gentar/biology/plan/phenotyping/TissueDistributionDTO.java
+++ b/impc_prod_tracker/dto/src/main/java/org/gentar/biology/plan/phenotyping/TissueDistributionDTO.java
@@ -26,6 +26,6 @@ public class TissueDistributionDTO
     private Long id;
     private LocalDateTime startDate;
     private LocalDateTime endDate;
-    private String centreName;
+    private String workUnitName;
     private String materialDepositedTypeName;
 }


### PR DESCRIPTION
Changed name in DTO so the work unit name is correctly mapped.