### PR TITLE
PUT endpoint for project

### DIFF
--- a/impc_prod_tracker/core/src/main/java/org/gentar/audit/AuditListener.java
+++ b/impc_prod_tracker/core/src/main/java/org/gentar/audit/AuditListener.java
@@ -41,8 +41,7 @@ public class AuditListener
         long id = ObjectIdExtractor.getObjectId(originalObject);
         HistoryService historyService = BeanUtil.getBean(HistoryService.class);
         String entityName = originalObject.getClass().getSimpleName();
-        historyService.setEntityData(entityName, id);
-        History history = historyService.detectTrackOfChanges(originalObject, newObject);
+        History history = historyService.detectTrackOfChanges(originalObject, newObject, id);
         if (history != null)
         {
             history.setComment(entityName + " updated");

--- a/impc_prod_tracker/core/src/main/java/org/gentar/audit/history/HistoryBuilder.java
+++ b/impc_prod_tracker/core/src/main/java/org/gentar/audit/history/HistoryBuilder.java
@@ -18,22 +18,10 @@ public class HistoryBuilder<T>
     private SubjectRetriever subjectRetriever;
     private static final String RESOURCE_PRIVACY_PROPERTY_NAME = "resourcePrivacy";
     private static final String RESTRICTED_OBJECT_PROPERTY_NAME = "restrictedObject";
-    private String entityName;
-    private Long entityId;
 
     public HistoryBuilder(SubjectRetriever subjectRetriever)
     {
         this.subjectRetriever = subjectRetriever;
-    }
-
-    public void setEntityName(String entityName)
-    {
-        this.entityName = entityName;
-    }
-
-    public void setEntityId(Long entityId)
-    {
-        this.entityId = entityId;
     }
 
     /**
@@ -41,9 +29,10 @@ public class HistoryBuilder<T>
      * as part as a update.
      * @param originalEntity The entity before the update.
      * @param newEntity The updated entity.
+     * @param id The id of the entity in the system.
      * @return {@link History} object with the information or null if no changes where detected.
      */
-    public History buildHistoryEntry(T originalEntity, T newEntity)
+    public History buildHistoryEntry(T originalEntity, T newEntity, Long id)
     {
         History history = new History();
         List<HistoryDetail> historyDetails = getDetails(originalEntity, newEntity);
@@ -53,14 +42,33 @@ public class HistoryBuilder<T>
         }
         else
         {
-            history.setEntityId(entityId);
-            history.setEntityName(entityName);
+            history.setEntityId(id);
+            history.setEntityName(originalEntity.getClass().getSimpleName());
             history.setDate(LocalDateTime.now());
             history.setComment(originalEntity.getClass().getSimpleName() + " updated");
             history.setHistoryDetailSet(historyDetails);
             history.setUser(subjectRetriever.getSubject().getLogin());
         }
 
+        return history;
+    }
+
+    /**
+     * Creates a {@link History} entity with information about the creation of an entity in the system.
+     * @param entity The entity whose creation is being audited.
+     * @param id The id of the entity.Entity can be any class so we cannot just use a method to
+     *           get the id.
+     * @return A record saying that the entity was created. There is NO details as that is used to
+     *          log the changes done in an object (update rather than creation).
+     */
+    public History buildCreationHistoryEntry(T entity, Long id)
+    {
+        History history = new History();
+        history.setEntityId(id);
+        history.setEntityName(entity.getClass().getSimpleName());
+        history.setDate(LocalDateTime.now());
+        history.setComment(entity.getClass().getSimpleName() + " created");
+        history.setUser(subjectRetriever.getSubject().getLogin());
         return history;
     }
 

--- a/impc_prod_tracker/core/src/main/java/org/gentar/audit/history/HistoryService.java
+++ b/impc_prod_tracker/core/src/main/java/org/gentar/audit/history/HistoryService.java
@@ -7,8 +7,8 @@ import java.util.List;
  */
 public interface HistoryService<T>
 {
-    History detectTrackOfChanges(T originalEntity, T newEntity);
+    History detectTrackOfChanges(T originalEntity, T newEntity, Long id);
     void saveTrackOfChanges(History historyEntry);
     List<History> getHistoryByEntityNameAndEntityId(String EntityName, Long EntityId);
-    void setEntityData(String entityName, Long entityId);
+    History buildCreationTrack(T entity, Long id);
 }

--- a/impc_prod_tracker/core/src/main/java/org/gentar/audit/history/HistoryServiceImpl.java
+++ b/impc_prod_tracker/core/src/main/java/org/gentar/audit/history/HistoryServiceImpl.java
@@ -21,9 +21,9 @@ public class HistoryServiceImpl<T> implements HistoryService<T>
     }
 
     @Override
-    public History detectTrackOfChanges(T originalEntity, T newEntity)
+    public History detectTrackOfChanges(T originalEntity, T newEntity, Long id)
     {
-        return historyBuilder.buildHistoryEntry(originalEntity, newEntity);
+        return historyBuilder.buildHistoryEntry(originalEntity, newEntity, id);
     }
 
     @Override
@@ -124,9 +124,8 @@ public class HistoryServiceImpl<T> implements HistoryService<T>
     }
 
     @Override
-    public void setEntityData(String entityName, Long entityId)
+    public History buildCreationTrack(T entity, Long id)
     {
-        historyBuilder.setEntityName(entityName);
-        historyBuilder.setEntityId(entityId);
+        return historyBuilder.buildCreationHistoryEntry(entity, id);
     }
 }

--- a/impc_prod_tracker/core/src/main/java/org/gentar/biology/outcome/OutcomeUpdater.java
+++ b/impc_prod_tracker/core/src/main/java/org/gentar/biology/outcome/OutcomeUpdater.java
@@ -25,7 +25,6 @@ public class OutcomeUpdater
 
     History update(Outcome originalOutcome, Outcome newOutcome)
     {
-        historyService.setEntityData(Outcome.class.getSimpleName(), originalOutcome.getId());
         validatePermission(newOutcome);
         validateData(newOutcome);
         changeStatusIfNeeded(newOutcome);
@@ -66,7 +65,6 @@ public class OutcomeUpdater
 
     private History detectTrackOfChanges(Outcome originalOutcome, Outcome newOutcome)
     {
-        History historyEntry = historyService.detectTrackOfChanges(originalOutcome, newOutcome);
-        return historyEntry;
+        return historyService.detectTrackOfChanges(originalOutcome, newOutcome, originalOutcome.getId());
     }
 }

--- a/impc_prod_tracker/core/src/main/java/org/gentar/biology/plan/engine/PlanUpdaterImpl.java
+++ b/impc_prod_tracker/core/src/main/java/org/gentar/biology/plan/engine/PlanUpdaterImpl.java
@@ -35,7 +35,6 @@ public class PlanUpdaterImpl implements PlanUpdater
     @Override
     public History updatePlan(Plan originalPlan, Plan newPlan)
     {
-        historyService.setEntityData(Plan.class.getSimpleName(), originalPlan.getId());
         validatePermissionToUpdatePlan(newPlan);
         validateData(newPlan);
         changeStatusIfNeeded(newPlan);
@@ -96,8 +95,7 @@ public class PlanUpdaterImpl implements PlanUpdater
      */
     private History detectTrackOfChanges(Plan originalPlan, Plan newPlan)
     {
-        History historyEntry = historyService.detectTrackOfChanges(originalPlan, newPlan);
-        return historyEntry;
+        return historyService.detectTrackOfChanges(originalPlan, newPlan, originalPlan.getId());
     }
 
     /**

--- a/impc_prod_tracker/core/src/main/java/org/gentar/biology/project/engine/ProjectCreator.java
+++ b/impc_prod_tracker/core/src/main/java/org/gentar/biology/project/engine/ProjectCreator.java
@@ -15,6 +15,8 @@
  *******************************************************************************/
 package org.gentar.biology.project.engine;
 
+import org.gentar.audit.history.History;
+import org.gentar.audit.history.HistoryService;
 import org.gentar.biology.project.assignment.AssignmentStatus;
 import org.gentar.biology.project.assignment.AssignmentStatusUpdater;
 import org.springframework.stereotype.Component;
@@ -35,9 +37,13 @@ public class ProjectCreator
 
     private AssignmentStatusUpdater assignmentStatusUpdater;
 
-    public ProjectCreator(AssignmentStatusUpdater assignmentStatusUpdater)
+    private HistoryService<Project> historyService;
+
+    public ProjectCreator(
+        AssignmentStatusUpdater assignmentStatusUpdater, HistoryService<Project> historyService)
     {
         this.assignmentStatusUpdater = assignmentStatusUpdater;
+        this.historyService = historyService;
     }
 
     /**
@@ -49,7 +55,7 @@ public class ProjectCreator
     {
         project.setAssignmentStatus(getInitialAssignmentStatus(project));
         Project createdProject = saveProject(project);
-        registerCreationInHistory();
+        registerCreationInHistory(project);
         return createdProject;
     }
 
@@ -60,9 +66,10 @@ public class ProjectCreator
         return project;
     }
 
-    private void registerCreationInHistory()
+    private void registerCreationInHistory(Project project)
     {
-        // TODO history for Project creation
+        History history = historyService.buildCreationTrack(project, project.getId());
+        historyService.saveTrackOfChanges(history);
     }
 
     private String buildTpn(Long id)

--- a/impc_prod_tracker/core/src/main/java/org/gentar/biology/project/engine/ProjectUpdater.java
+++ b/impc_prod_tracker/core/src/main/java/org/gentar/biology/project/engine/ProjectUpdater.java
@@ -20,10 +20,10 @@ public class ProjectUpdater
 
     public History updateProject(Project originalProject, Project newProject)
     {
-        historyService.setEntityData(Project.class.getSimpleName(), originalProject.getId());
         validatePermissions(newProject);
         changeAssignmentStatusIfNeeded(newProject);
-        History history = historyService.detectTrackOfChanges(originalProject, newProject);
+        History history =
+            historyService.detectTrackOfChanges(originalProject, newProject, originalProject.getId());
         saveChanges(newProject);
         saveTrackOfChanges(history);
         return history;

--- a/impc_prod_tracker/core/src/test/java/org/gentar/audit/history/HistoryBuilderTest.java
+++ b/impc_prod_tracker/core/src/test/java/org/gentar/audit/history/HistoryBuilderTest.java
@@ -43,8 +43,6 @@ public class HistoryBuilderTest
     public void testBuildHistoryEntry()
     {
         testInstance = new HistoryBuilder<>(subjectRetriever);
-        testInstance.setEntityId(1L);
-        testInstance.setEntityName(PlanMock.class.getSimpleName());
 
         SubStatusMock subStatusMock1 = new SubStatusMock(1L, "subStatusMock1");
         StatusMock statusMock1 = new StatusMock(1L, "statusMock1", subStatusMock1);
@@ -70,7 +68,7 @@ public class HistoryBuilderTest
         planMock2.setWorkUnitList(Arrays.asList(workUnitMock2A, workUnitMock2B));
         planMock2.setPrivacy(privacyMock2);
 
-        History history = testInstance.buildHistoryEntry(planMock1, planMock2);
+        History history = testInstance.buildHistoryEntry(planMock1, planMock2, 1L);
 
         assertThat("History record not generated:", history, is(notNullValue()));
 


### PR DESCRIPTION
- Removed setEntityData in HistoryService: now the entityName is calculated from the object and the id is passed as parameter where needed.
- Register in history when a project is created.