### PR TITLE
Allow to ignore fields when checking object diff#438

### DIFF
--- a/impc_prod_tracker/core/src/main/java/org/gentar/audit/diff/IgnoreForAuditingChanges.java
+++ b/impc_prod_tracker/core/src/main/java/org/gentar/audit/diff/IgnoreForAuditingChanges.java
@@ -1,0 +1,16 @@
+package org.gentar.audit.diff;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * This annotation is used to mark fields that need to be ignored when calculating the diff of
+ * 2 versions of a entity (to check what changed in an object).
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface IgnoreForAuditingChanges
+{
+}

--- a/impc_prod_tracker/core/src/main/java/org/gentar/audit/diff/PropertyChecker.java
+++ b/impc_prod_tracker/core/src/main/java/org/gentar/audit/diff/PropertyChecker.java
@@ -59,10 +59,18 @@ public class PropertyChecker
                 PropertyDefinition data = new PropertyDefinition();
                 data.setName(x.getName());
                 data.setType(x.getType());
-                dataList.add(data);
+                if (!isMarkedToIgnoreForAuditingChanges(x))
+                {
+                    dataList.add(data);
+                }
             });
 
         return dataList;
+    }
+
+    static boolean isMarkedToIgnoreForAuditingChanges(Field field)
+    {
+        return field.isAnnotationPresent(IgnoreForAuditingChanges.class);
     }
 
     static Class<?> getPropertyType(Object object, String propertyName)


### PR DESCRIPTION
- Created the annotation IgnoreForAuditingChanges to ignore a field to be checked for changes.
- Modified the PropertyChecker class to skip fields that are marked as "IgnoreForAuditingChanges".