### PR TITLE
Summary status assignation to project and Plan#459

### DIFF
--- a/impc_prod_tracker/core/src/main/java/org/gentar/biology/plan/Plan.java
+++ b/impc_prod_tracker/core/src/main/java/org/gentar/biology/plan/Plan.java
@@ -19,12 +19,15 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import lombok.ToString;
 import org.gentar.audit.diff.IgnoreForAuditingChanges;
 import org.gentar.biology.outcome.Outcome;
 import org.gentar.biology.plan.plan_starting_point.PlanStartingPoint;
 import org.gentar.biology.plan.status.PlanStatusStamp;
+import org.gentar.biology.plan.status.PlanSummaryStatusStamp;
 import org.gentar.biology.plan.type.PlanType;
 import org.gentar.organization.work_group.WorkGroup;
 import org.gentar.security.abac.Resource;
@@ -63,6 +66,8 @@ public class Plan extends BaseEntity implements Resource<Plan>, ProcessData
     private Long id;
 
     @Transient
+    @Getter
+    @Setter
     private ProcessEvent event;
 
     @EqualsAndHashCode.Include
@@ -95,6 +100,12 @@ public class Plan extends BaseEntity implements Resource<Plan>, ProcessData
     @ToString.Exclude
     @OneToMany(cascade= CascadeType.ALL, mappedBy = "plan")
     private Set<PlanStatusStamp> planStatusStamps;
+
+    @IgnoreForAuditingChanges
+    @EqualsAndHashCode.Exclude
+    @ToString.Exclude
+    @OneToMany(cascade= CascadeType.ALL, mappedBy = "plan")
+    private Set<PlanSummaryStatusStamp> planSummaryStatusStamps;
 
     @NotNull
     @ManyToOne(targetEntity= Status.class)
@@ -198,11 +209,5 @@ public class Plan extends BaseEntity implements Resource<Plan>, ProcessData
     public List<Consortium> getRelatedConsortia()
     {
         return Collections.emptyList();
-    }
-
-    @Override
-    public ProcessEvent getEvent()
-    {
-        return this.event;
     }
 }

--- a/impc_prod_tracker/core/src/main/java/org/gentar/biology/plan/PlanStatusManager.java
+++ b/impc_prod_tracker/core/src/main/java/org/gentar/biology/plan/PlanStatusManager.java
@@ -1,0 +1,67 @@
+package org.gentar.biology.plan;
+
+import org.gentar.biology.plan.engine.PlanStateMachineResolver;
+import org.gentar.biology.plan.engine.PlanStateSetter;
+import org.gentar.biology.plan.status.PlanSummaryStatusUpdater;
+import org.gentar.biology.status.StatusNames;
+import org.gentar.statemachine.StateTransitionsManager;
+import org.gentar.statemachine.SystemEventsExecutor;
+import org.springframework.stereotype.Component;
+
+/**
+ * Class in charge of calculating and modifying the status in a plan.
+ */
+@Component
+public class PlanStatusManager
+{
+    private StateTransitionsManager stateTransitionManager;
+    private SystemEventsExecutor systemEventsExecutor;
+    private PlanStateSetter planStateSetter;
+    private PlanSummaryStatusUpdater planSummaryStatusUpdater;
+
+    public PlanStatusManager(
+        StateTransitionsManager stateTransitionManager,
+        SystemEventsExecutor systemEventsExecutor,
+        PlanStateSetter planStateSetter,
+        PlanSummaryStatusUpdater planSummaryStatusUpdater)
+    {
+        this.stateTransitionManager = stateTransitionManager;
+        this.systemEventsExecutor = systemEventsExecutor;
+        this.planStateSetter = planStateSetter;
+        this.planSummaryStatusUpdater = planSummaryStatusUpdater;
+    }
+
+    public void setInitialStatus(Plan plan)
+    {
+        planStateSetter.setStatusByName(plan, StatusNames.PLAN_CREATED);
+    }
+
+    public void setSummaryStatus(Plan plan)
+    {
+        planSummaryStatusUpdater.setSummaryStatus(plan);
+    }
+
+    /**
+     * Check if the changes in the plan require a change on the status.
+     * @param plan Plan being updated.
+     */
+    public void updateStatusIfNeeded(Plan plan)
+    {
+        executeSystemTriggeredTransitions(plan);
+        executeUserTriggeredTransitions(plan);
+    }
+
+    private void executeSystemTriggeredTransitions(Plan plan)
+    {
+        systemEventsExecutor.setStateMachineResolver(new PlanStateMachineResolver());
+        systemEventsExecutor.execute(plan);
+    }
+
+    private void executeUserTriggeredTransitions(Plan plan)
+    {
+        if (plan.getEvent() != null)
+        {
+            stateTransitionManager.processEvent(plan);
+        }
+    }
+}

--- a/impc_prod_tracker/core/src/main/java/org/gentar/biology/plan/attempt/phenotyping/PhenotypingAttempt.java
+++ b/impc_prod_tracker/core/src/main/java/org/gentar/biology/plan/attempt/phenotyping/PhenotypingAttempt.java
@@ -5,10 +5,8 @@ import org.gentar.BaseEntity;
 import org.gentar.biology.plan.Plan;
 import org.gentar.biology.plan.attempt.phenotyping.stage.PhenotypingStage;
 import org.gentar.biology.strain.Strain;
-
 import javax.persistence.*;
 import javax.validation.constraints.NotNull;
-import java.util.List;
 import java.util.Set;
 
 @NoArgsConstructor(access= AccessLevel.PUBLIC, force=true)

--- a/impc_prod_tracker/core/src/main/java/org/gentar/biology/plan/attempt/phenotyping/stage/PhenotypingStage.java
+++ b/impc_prod_tracker/core/src/main/java/org/gentar/biology/plan/attempt/phenotyping/stage/PhenotypingStage.java
@@ -10,7 +10,6 @@ import org.gentar.biology.plan.attempt.phenotyping.stage.type.PhenotypingStageTy
 import org.gentar.biology.status.Status;
 import org.gentar.statemachine.ProcessData;
 import org.gentar.statemachine.ProcessEvent;
-
 import javax.persistence.*;
 import javax.validation.constraints.NotNull;
 import java.time.LocalDate;
@@ -59,10 +58,4 @@ public class PhenotypingStage extends BaseEntity implements ProcessData
     @ToString.Exclude
     @OneToMany(cascade= CascadeType.ALL, mappedBy = "phenotypingStage")
     private Set<PhenotypingStageStatusStamp> phenotypingStageStatusStamps;
-
-    @Override
-    public ProcessEvent getEvent()
-    {
-        return this.event;
-    }
 }

--- a/impc_prod_tracker/core/src/main/java/org/gentar/biology/plan/engine/PlanStateMachineResolver.java
+++ b/impc_prod_tracker/core/src/main/java/org/gentar/biology/plan/engine/PlanStateMachineResolver.java
@@ -6,7 +6,9 @@ import org.gentar.biology.plan.engine.events.BreedingPlanEvent;
 import org.gentar.biology.plan.engine.events.CrisprProductionPlanEvent;
 import org.gentar.biology.plan.engine.events.PhenotypePlanEvent;
 import org.gentar.exceptions.SystemOperationFailedException;
+import org.gentar.statemachine.ProcessData;
 import org.gentar.statemachine.ProcessEvent;
+import org.gentar.statemachine.StateMachineResolver;
 import org.springframework.stereotype.Component;
 import java.util.ArrayList;
 import java.util.List;
@@ -15,19 +17,12 @@ import java.util.List;
  * This class handles the different state machines that a plan can have
  */
 @Component
-public class PlanStateMachineResolver
+public class PlanStateMachineResolver implements StateMachineResolver
 {
-    /**
-     * Given a plan and an action, this method returns the event (transition) in the suitable state
-     * machine that can be later be executed on the project.
-     * @param plan Plan that is being evaluate.
-     * @param actionName Action to execute on the plan.
-     * @return a {@link ProcessEvent} object with the description of the transition to execute,
-     * linked to a specific state machine.
-     */
-    public ProcessEvent getProcessEventByActionName(Plan plan, String actionName)
+    @Override
+    public ProcessEvent getProcessEventByActionName(ProcessData processData, String actionName)
     {
-        List<ProcessEvent> allEvents = getProcessEventsByPlan(plan);
+        List<ProcessEvent> allEvents = getProcessEventsByPlan((Plan)processData);
         for (ProcessEvent processEvent : allEvents)
         {
             if (processEvent.getName().equalsIgnoreCase(actionName))
@@ -36,16 +31,11 @@ public class PlanStateMachineResolver
         return null;
     }
 
-    /**
-     * Get the possible transitions for a plan. The type plan or attempt type define the state
-     * machine and the current plan's status defines the available transitions from that state machine.
-     * @param plan Plan being evaluated.
-     * @return A list of {@link ProcessEvent} (transitions) that can be executed in the plan.
-     */
-    public List<ProcessEvent> getAvailableTransitionsByPlanStatus(Plan plan)
+    @Override
+    public List<ProcessEvent> getAvailableTransitionsByEntityStatus(ProcessData processData)
     {
         return getAvailableEventsByStateName(
-            getProcessEventsByPlan(plan), plan.getStatus().getName());
+            getProcessEventsByPlan((Plan)processData), processData.getStatus().getName());
     }
 
     private List<ProcessEvent> getAvailableEventsByStateName(
@@ -79,7 +69,7 @@ public class PlanStateMachineResolver
             case CRISPR:
                 processEvents = CrisprProductionPlanEvent.getAllEvents();
                 break;
-            case ADULT_PHENOTYPING : case HAPLOESSENTIAL_PHENOTYPING:
+            case ADULT_PHENOTYPING: case HAPLOESSENTIAL_PHENOTYPING:
                 processEvents = PhenotypePlanEvent.getAllEvents();
                 break;
             case BREEDING:
@@ -91,4 +81,5 @@ public class PlanStateMachineResolver
         }
         return processEvents;
     }
+
 }

--- a/impc_prod_tracker/core/src/main/java/org/gentar/biology/plan/engine/PlanStateSetter.java
+++ b/impc_prod_tracker/core/src/main/java/org/gentar/biology/plan/engine/PlanStateSetter.java
@@ -4,13 +4,19 @@ import org.gentar.biology.plan.Plan;
 import org.gentar.biology.plan.status.PlanStatusStamp;
 import org.gentar.biology.status.Status;
 import org.gentar.biology.status.StatusService;
+import org.gentar.statemachine.ProcessData;
+import org.gentar.statemachine.StateSetter;
 import org.springframework.stereotype.Component;
 import java.time.LocalDateTime;
 import java.util.HashSet;
 import java.util.Set;
 
+/**
+ * Any class wanting to set the status in a plan needs to call this class to do that.
+ * This class sets the new status and registers the action in the stamp table for plan statuses.
+ */
 @Component
-public class PlanStateSetter
+public class PlanStateSetter implements StateSetter
 {
     private StatusService statusService;
 
@@ -19,16 +25,22 @@ public class PlanStateSetter
         this.statusService = statusService;
     }
 
+    @Override
+    public void setStatus(ProcessData entity, Status status)
+    {
+        entity.setStatus(status);
+        registerStatusStamp((Plan)entity);
+    }
+
     /**
      * Sets the status for a plan. It also record the stamp so there is historic information.
-     * @param plan The plan to be updated.
+     * @param entity The entity to be updated.
      * @param statusName A string with the name of the status.
      */
-    public void setStatusByName(Plan plan, String statusName)
+    public void setStatusByName(ProcessData entity, String statusName)
     {
         Status newPlanStatus = statusService.getStatusByName(statusName);
-        plan.setStatus(newPlanStatus);
-        registerStatusStamp(plan);
+        setStatus(entity, newPlanStatus);
     }
 
     private void registerStatusStamp(Plan plan)

--- a/impc_prod_tracker/core/src/main/java/org/gentar/biology/plan/engine/PlanUpdaterImpl.java
+++ b/impc_prod_tracker/core/src/main/java/org/gentar/biology/plan/engine/PlanUpdaterImpl.java
@@ -1,11 +1,11 @@
 package org.gentar.biology.plan.engine;
 
+import org.gentar.biology.plan.PlanStatusManager;
 import org.gentar.biology.plan.Plan_;
 import org.gentar.biology.project.ProjectService;
 import org.gentar.biology.status.Status_;
 import org.gentar.exceptions.UserOperationFailedException;
 import org.gentar.audit.history.HistoryService;
-import org.gentar.statemachine.StateTransitionsManager;
 import org.springframework.stereotype.Component;
 import org.gentar.security.abac.spring.ContextAwarePolicyEnforcement;
 import org.gentar.biology.plan.Plan;
@@ -20,23 +20,23 @@ public class PlanUpdaterImpl implements PlanUpdater
     private ContextAwarePolicyEnforcement policyEnforcement;
     private PlanRepository planRepository;
     private PlanValidator planValidator;
-    private StateTransitionsManager stateTransitionManager;
     private ProjectService projectService;
+    private PlanStatusManager planStatusManager;
 
     public PlanUpdaterImpl(
         HistoryService<Plan> historyService,
         ContextAwarePolicyEnforcement policyEnforcement,
         PlanRepository planRepository,
         PlanValidator planValidator,
-        StateTransitionsManager stateTransitionManager,
-        ProjectService projectService)
+        ProjectService projectService,
+        PlanStatusManager planStatusManager)
     {
         this.historyService = historyService;
         this.policyEnforcement = policyEnforcement;
         this.planRepository = planRepository;
         this.planValidator = planValidator;
-        this.stateTransitionManager = stateTransitionManager;
         this.projectService = projectService;
+        this.planStatusManager = planStatusManager;
     }
 
     @Override
@@ -72,10 +72,7 @@ public class PlanUpdaterImpl implements PlanUpdater
      */
     private void changeStatusIfNeeded(Plan plan)
     {
-        if (plan.getEvent() != null)
-        {
-             stateTransitionManager.processEvent(plan);
-        }
+        planStatusManager.updateStatusIfNeeded(plan);
     }
 
     /**

--- a/impc_prod_tracker/core/src/main/java/org/gentar/biology/plan/engine/events/CrisprProductionPlanEvent.java
+++ b/impc_prod_tracker/core/src/main/java/org/gentar/biology/plan/engine/events/CrisprProductionPlanEvent.java
@@ -1,12 +1,15 @@
 package org.gentar.biology.plan.engine.events;
 
 import org.gentar.biology.plan.engine.PlanProcessor;
+import org.gentar.biology.plan.engine.processors.crispr.CrisprPlanAttemptInProgressProcessor;
 import org.gentar.biology.plan.engine.state.CrisprProductionPlanState;
 import org.gentar.biology.plan.engine.processors.PlanAbortProcessor;
 import org.gentar.biology.plan.engine.processors.PlanAbortReverserProcessor;
 import org.gentar.statemachine.ProcessEvent;
 import org.gentar.statemachine.ProcessState;
 import org.gentar.statemachine.Processor;
+import org.gentar.statemachine.StateMachineConstants;
+
 import java.util.Arrays;
 import java.util.List;
 
@@ -16,7 +19,7 @@ public enum CrisprProductionPlanEvent implements ProcessEvent
             "Abort the plan that is in progress",
             CrisprProductionPlanState.AttemptInProgress,
             CrisprProductionPlanState.AttemptAborted,
-            true,
+            StateMachineConstants.TRIGGERED_BY_USER,
             null)
             {
                 @Override
@@ -29,7 +32,7 @@ public enum CrisprProductionPlanEvent implements ProcessEvent
             "Abort the plan that has been created",
             CrisprProductionPlanState.PlanCreated,
             CrisprProductionPlanState.AttemptAborted,
-            true,
+            StateMachineConstants.TRIGGERED_BY_USER,
             null)
             {
                 @Override
@@ -38,29 +41,36 @@ public enum CrisprProductionPlanEvent implements ProcessEvent
                     return PlanAbortProcessor.class;
                 }
             },
-    inProgress(
+    changeToInProgress(
             "Attempt in progress",
             CrisprProductionPlanState.PlanCreated,
             CrisprProductionPlanState.AttemptInProgress,
-            false,
-            "executed by the system when details of the attempt are registered"),
-    embryosObtained(
+            StateMachineConstants.NOT_TRIGGERED_BY_USER,
+            "executed by the system when details of the attempt are registered")
+        {
+            @Override
+            public Class<? extends Processor> getNextStepProcessor()
+            {
+                return CrisprPlanAttemptInProgressProcessor.class;
+            }
+        },
+    changeToEmbryosObtained(
             "Embryos obtained from the attempt",
             CrisprProductionPlanState.AttemptInProgress,
             CrisprProductionPlanState.EmbryosObtained,
-            false,
+            StateMachineConstants.NOT_TRIGGERED_BY_USER,
             "executed by the system when injected embryos are registered"),
-    glt(
+    changeToGlt(
             "Germ line transmission obtained for the attempt",
             CrisprProductionPlanState.EmbryosObtained,
             CrisprProductionPlanState.GLT,
-            false,
+            StateMachineConstants.NOT_TRIGGERED_BY_USER,
             "executed by the system when germ line transmission is registered."),
     reverseAbortion(
             "Reverse abortion",
             CrisprProductionPlanState.AttemptAborted,
             CrisprProductionPlanState.PlanCreated,
-            true,
+            StateMachineConstants.TRIGGERED_BY_USER,
             null)
             {
                 @Override
@@ -73,7 +83,7 @@ public enum CrisprProductionPlanEvent implements ProcessEvent
             "Abort the plan after embryos obtained",
             CrisprProductionPlanState.EmbryosObtained,
             CrisprProductionPlanState.AttemptAborted,
-            true,
+            StateMachineConstants.TRIGGERED_BY_USER,
             null)
             {
                 @Override
@@ -86,7 +96,7 @@ public enum CrisprProductionPlanEvent implements ProcessEvent
             "Abort the plan after germ line transmission obtained",
             CrisprProductionPlanState.GLT,
             CrisprProductionPlanState.AttemptAborted,
-            true,
+            StateMachineConstants.TRIGGERED_BY_USER,
             null)
             {
                 @Override

--- a/impc_prod_tracker/core/src/main/java/org/gentar/biology/plan/engine/processors/crispr/CrisprPlanAttemptInProgressProcessor.java
+++ b/impc_prod_tracker/core/src/main/java/org/gentar/biology/plan/engine/processors/crispr/CrisprPlanAttemptInProgressProcessor.java
@@ -1,0 +1,45 @@
+package org.gentar.biology.plan.engine.processors.crispr;
+
+import org.gentar.biology.plan.Plan;
+import org.gentar.biology.plan.engine.PlanStateSetter;
+import org.gentar.biology.plan.engine.state.CrisprProductionPlanState;
+import org.gentar.statemachine.ProcessData;
+import org.gentar.statemachine.ProcessEvent;
+import org.gentar.statemachine.ProcessState;
+import org.gentar.statemachine.Processor;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CrisprPlanAttemptInProgressProcessor implements Processor
+{
+    private PlanStateSetter planStateSetter;
+
+    public CrisprPlanAttemptInProgressProcessor(PlanStateSetter planStateSetter)
+    {
+        this.planStateSetter = planStateSetter;
+    }
+
+    @Override
+    public ProcessData process(ProcessData data)
+    {
+        tryToMoveToAttemptInProgress((Plan)data);
+        return data;
+    }
+
+    private void tryToMoveToAttemptInProgress(Plan plan)
+    {
+        if (canMoveToAttemptInProgress(plan))
+        {
+            ProcessEvent processEvent = plan.getEvent();
+            ProcessState endState = processEvent.getEndState();
+            assert(endState.equals(CrisprProductionPlanState.AttemptInProgress));
+            String statusName = endState.getInternalName();
+            planStateSetter.setStatusByName(plan, statusName);
+        }
+    }
+
+    private boolean canMoveToAttemptInProgress(Plan plan)
+    {
+        return plan.getCrisprAttempt() != null;
+    }
+}

--- a/impc_prod_tracker/core/src/main/java/org/gentar/biology/plan/status/PlanSummaryStatusUpdater.java
+++ b/impc_prod_tracker/core/src/main/java/org/gentar/biology/plan/status/PlanSummaryStatusUpdater.java
@@ -1,0 +1,111 @@
+package org.gentar.biology.plan.status;
+
+import org.gentar.biology.colony.Colony;
+import org.gentar.biology.outcome.Outcome;
+import org.gentar.biology.plan.Plan;
+import org.gentar.biology.plan.attempt.phenotyping.PhenotypingAttempt;
+import org.gentar.biology.plan.attempt.phenotyping.stage.PhenotypingStage;
+import org.gentar.biology.project.Project;
+import org.gentar.biology.project.summary_status.ProjectSummaryStatusStamp;
+import org.gentar.biology.status.Status;
+import org.gentar.biology.status.StatusService;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Class in charge of setting/updating the summary status in a plan, as well as recording that
+ * change in the plan summary status stamp table.
+ */
+@Component
+public class PlanSummaryStatusUpdater
+{
+    private StatusService statusService;
+
+    public PlanSummaryStatusUpdater(StatusService statusService)
+    {
+        this.statusService = statusService;
+    }
+
+    public void setSummaryStatus(Plan plan)
+    {
+        List<Status> statuses = getChildrenStatus(plan);
+        statuses.add(plan.getStatus());
+        Status mostAdvancedStatus = statuses
+            .stream()
+            .max(Comparator.comparing(Status::getOrdering))
+            .orElse(null);
+        setSummaryStatus(plan, mostAdvancedStatus);
+    }
+
+    public List<Status> getChildrenStatus(Plan plan)
+    {
+        List<Status> statuses = new ArrayList<>();
+        statuses.addAll(getOutcomesStatuses(plan));
+        statuses.addAll(getPhenotypingStagesStatuses(plan));
+        return statuses;
+    }
+
+    public List<Status> getOutcomesStatuses(Plan plan)
+    {
+        List<Status> outcomeStatuses = new ArrayList<>();
+        Set<Outcome> outcomes = plan.getOutcomes();
+        if (outcomes != null)
+        {
+            outcomes.forEach(x -> {
+                Colony colony = x.getColony();
+                if (colony != null)
+                {
+                    outcomeStatuses.add(colony.getStatus());
+                }
+            });
+        }
+        return outcomeStatuses;
+    }
+
+    public List<Status> getPhenotypingStagesStatuses(Plan plan)
+    {
+        List<Status> phenotypingStagesStatuses = new ArrayList<>();
+        PhenotypingAttempt phenotypingAttempt = plan.getPhenotypingAttempt();
+        Set<PhenotypingStage> phenotypingStages =
+            phenotypingAttempt == null ? null : phenotypingAttempt.getPhenotypingStages();
+        if (phenotypingStages != null )
+        {
+            phenotypingStages.forEach(x -> {
+                phenotypingStagesStatuses.add(x.getStatus());
+            });
+        }
+        return phenotypingStagesStatuses;
+    }
+
+    private void setSummaryStatus(Plan plan, Status summaryStatus)
+    {
+        String originalStatusName =
+            plan.getSummaryStatus() == null ? "" : plan.getSummaryStatus().getName();
+        if (!originalStatusName.equals(summaryStatus.getName()))
+        {
+            plan.setSummaryStatus(summaryStatus);
+            registerSummaryStatusStamp(plan);
+        }
+    }
+
+    private void registerSummaryStatusStamp(Plan plan)
+    {
+        Set<PlanSummaryStatusStamp> stamps = plan.getPlanSummaryStatusStamps();
+        if (stamps == null)
+        {
+            stamps = new HashSet<>();
+        }
+        PlanSummaryStatusStamp planSummaryStatusStamp = new PlanSummaryStatusStamp();
+        planSummaryStatusStamp.setPlan(plan);
+        planSummaryStatusStamp.setStatus(plan.getSummaryStatus());
+        planSummaryStatusStamp.setDate(LocalDateTime.now());
+        stamps.add(planSummaryStatusStamp);
+        plan.setPlanSummaryStatusStamps(stamps);
+    }
+}

--- a/impc_prod_tracker/core/src/main/java/org/gentar/biology/project/engine/ProjectHistoryRecorder.java
+++ b/impc_prod_tracker/core/src/main/java/org/gentar/biology/project/engine/ProjectHistoryRecorder.java
@@ -26,10 +26,13 @@ public class ProjectHistoryRecorder
         History history =
             historyService.detectTrackOfChanges(
                 originalProject, newProject, originalProject.getId());
-        history = historyService.filterDetailsInNestedEntity(
-            history, Project_.ASSIGNMENT_STATUS, AssignmentStatus_.NAME);
-        history = historyService.filterDetailsInNestedEntity(
-            history, Project_.SUMMARY_STATUS, AssignmentStatus_.NAME);
-        historyService.saveTrackOfChanges(history);
+        if (history != null)
+        {
+            history = historyService.filterDetailsInNestedEntity(
+                history, Project_.ASSIGNMENT_STATUS, AssignmentStatus_.NAME);
+            history = historyService.filterDetailsInNestedEntity(
+                history, Project_.SUMMARY_STATUS, AssignmentStatus_.NAME);
+            historyService.saveTrackOfChanges(history);
+        }
     }
 }

--- a/impc_prod_tracker/core/src/main/java/org/gentar/statemachine/ProcessData.java
+++ b/impc_prod_tracker/core/src/main/java/org/gentar/statemachine/ProcessData.java
@@ -1,9 +1,14 @@
 package org.gentar.statemachine;
 
+import org.gentar.biology.status.Status;
+
 /**
  * Interface to be implemented by the entity to be processed in the state machine.
  */
 public interface ProcessData
 {
     ProcessEvent getEvent();
+    void setEvent(ProcessEvent processEvent);
+    Status getStatus();
+    void setStatus(Status status);
 }

--- a/impc_prod_tracker/core/src/main/java/org/gentar/statemachine/StateMachineResolver.java
+++ b/impc_prod_tracker/core/src/main/java/org/gentar/statemachine/StateMachineResolver.java
@@ -1,0 +1,25 @@
+package org.gentar.statemachine;
+
+
+import java.util.List;
+
+public interface StateMachineResolver
+{
+    /**
+     * Given a processData and an action, this method returns the event (transition) in the
+     * suitable state machine that can be later be executed on the entity.
+     * @param processData Entity that is being evaluate.
+     * @param actionName Action to execute on the plan.
+     * @return a {@link ProcessEvent} object with the description of the transition to execute,
+     * linked to a specific state machine.
+     */
+    ProcessEvent getProcessEventByActionName(ProcessData processData, String actionName);
+
+    /**
+     * Get the possible transitions for a entity. The type plan or attempt type define the state
+     * machine and the current plan's status defines the available transitions from that state machine.
+     * @param processData Entity being evaluated.
+     * @return A list of {@link ProcessEvent} (transitions) that can be executed in the entity.
+     */
+    List<ProcessEvent> getAvailableTransitionsByEntityStatus(ProcessData processData);
+}

--- a/impc_prod_tracker/core/src/main/java/org/gentar/statemachine/StateSetter.java
+++ b/impc_prod_tracker/core/src/main/java/org/gentar/statemachine/StateSetter.java
@@ -1,0 +1,19 @@
+package org.gentar.statemachine;
+
+import org.gentar.biology.status.Status;
+
+public interface StateSetter
+{
+    /**
+     * Sets the status for an entity. It also record the stamp so there is historic information.
+     * @param entity The entity to be updated.
+     * @param status The new status.
+     */
+    void setStatus(ProcessData entity, Status status);
+    /**
+     * Sets the status for an entity. It also record the stamp so there is historic information.
+     * @param entity The entity to be updated.
+     * @param statusName A string with the name of the status.
+     */
+    void setStatusByName(ProcessData entity, String statusName);
+}

--- a/impc_prod_tracker/core/src/main/java/org/gentar/statemachine/SystemEventsExecutor.java
+++ b/impc_prod_tracker/core/src/main/java/org/gentar/statemachine/SystemEventsExecutor.java
@@ -1,0 +1,102 @@
+package org.gentar.statemachine;
+
+import lombok.Setter;
+import org.gentar.biology.status.Status;
+import org.gentar.exceptions.SystemOperationFailedException;
+import org.gentar.exceptions.UserOperationFailedException;
+import org.springframework.stereotype.Component;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * This class executes the transitions (events) that are triggered by the system.
+ * When the entity to process has some specific data, the system can trigger a change in the state.
+ * This class should be generic enough so it needs some classes to be set in order to manage
+ * the logic of saving data in history.
+ */
+@Component
+@Setter
+public class SystemEventsExecutor
+{
+    private StateTransitionsManager stateTransitionManager;
+    private static final String USER_ACTION_PRESENT_ERROR_MESSAGE =
+        "Trying to execute action [%s] but also modifying data that causes a change in status. " +
+            "Please do this in two different steps.";
+
+    public SystemEventsExecutor(StateTransitionsManager stateTransitionManager)
+    {
+        this.stateTransitionManager = stateTransitionManager;
+    }
+
+    private StateMachineResolver stateMachineResolver;
+    private ProcessEvent originalEvent;
+
+    /**
+     * Tries to execute as many system triggered transitions as possible for an entity.
+     * System triggered transitions can only be executed if there is not a transition triggered
+     * by the user at the same time. If that's the case a
+     * {@link UserOperationFailedException} is thrown.
+     * @param entity Entity to be processed.
+     * @throws {@link UserOperationFailedException} if at a system triggered transition is going
+     * to be executed when at the same time there is a user triggered transition for the entity.
+     */
+
+    public void execute(ProcessData entity)
+    {
+        originalEvent = entity.getEvent();
+        executeNextTransitions(entity);
+    }
+
+    private void executeNextTransitions(ProcessData entity)
+    {
+        List<ProcessEvent> systemTransitions = getSystemTransitions(entity);
+        for (ProcessEvent transition: systemTransitions)
+        {
+            boolean couldExecuteTransition = tryToExecuteTransition(transition, entity);
+            if (couldExecuteTransition)
+            {
+                executeNextTransitions(entity);
+                break;
+            }
+        }
+    }
+
+    private boolean tryToExecuteTransition(ProcessEvent transition, ProcessData entity)
+    {
+        String statusNameBeforeTransition = entity.getStatus().getName();
+        entity.setEvent(transition);
+        Status newStatus = stateTransitionManager.processEvent(entity).getStatus();
+        boolean statusChanged = !statusNameBeforeTransition.equals(newStatus.getName());
+        // Already set in processor, needed here because assignation is lost in tests
+        entity.setStatus(newStatus);
+        if (statusChanged)
+        {
+            validateNoUserTriggeredTransitionIsPresent();
+        }
+        return statusChanged;
+    }
+
+    private List<ProcessEvent> getSystemTransitions(ProcessData entity)
+    {
+        if (stateMachineResolver == null)
+        {
+            throw new SystemOperationFailedException(
+                "System triggered transitions could not be executed",
+                "No StateTransitionsManager provided");
+        }
+        var allPossibleTransitions =
+            stateMachineResolver.getAvailableTransitionsByEntityStatus(entity);
+        return allPossibleTransitions.stream()
+            .filter(x -> !x.isTriggeredByUser())
+            .collect(Collectors.toList());
+    }
+
+    private void validateNoUserTriggeredTransitionIsPresent()
+    {
+        if (originalEvent != null && originalEvent.isTriggeredByUser())
+        {
+            throw new UserOperationFailedException(
+                String.format(USER_ACTION_PRESENT_ERROR_MESSAGE, originalEvent.getName()));
+        }
+    }
+}

--- a/impc_prod_tracker/core/src/test/java/org/gentar/statemachine/SystemEventsExecutorTest.java
+++ b/impc_prod_tracker/core/src/test/java/org/gentar/statemachine/SystemEventsExecutorTest.java
@@ -1,0 +1,134 @@
+package org.gentar.statemachine;
+
+import org.gentar.biology.plan.Plan;
+import org.gentar.biology.plan.attempt.AttemptTypes;
+import org.gentar.biology.plan.engine.PlanStateMachineResolver;
+import org.gentar.biology.plan.engine.events.CrisprProductionPlanEvent;
+import org.gentar.biology.plan.engine.state.CrisprProductionPlanState;
+import org.gentar.exceptions.SystemOperationFailedException;
+import org.gentar.exceptions.UserOperationFailedException;
+import org.gentar.test_util.PlanBuilder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class SystemEventsExecutorTest
+{
+    private SystemEventsExecutor testInstance;
+    private PlanStateMachineResolver planStateMachineResolver = new PlanStateMachineResolver();
+
+    @Mock
+    private StateTransitionsManager stateTransitionsManager;
+
+    @BeforeEach
+    public void setup()
+    {
+        testInstance = new SystemEventsExecutor(stateTransitionsManager);
+    }
+
+    @Test
+    public void testWhenOnlyOneTransition()
+    {
+        Plan planCreated = PlanBuilder.getInstance()
+            .withStatus(CrisprProductionPlanState.PlanCreated.getInternalName())
+            .withAttemptType(AttemptTypes.CRISPR.getTypeName())
+            .build();
+        Plan planWithAttemptInProgress = PlanBuilder.getInstance()
+            .withStatus(CrisprProductionPlanState.AttemptInProgress.getInternalName())
+            .withAttemptType(AttemptTypes.CRISPR.getTypeName())
+            .build();
+
+        testInstance.setStateMachineResolver(planStateMachineResolver);
+        when(stateTransitionsManager.processEvent(any(Plan.class)))
+            .thenReturn(planWithAttemptInProgress);
+
+        testInstance.execute(planCreated);
+
+        verify(stateTransitionsManager, times(2)).processEvent(any(Plan.class));
+        assertThat(
+            "Not expected status",
+            planCreated.getStatus().getName(),
+            is(CrisprProductionPlanState.AttemptInProgress.getInternalName()));
+    }
+
+    @Test
+    public void testWhenMoreThanTwoTransition()
+    {
+        Plan planCreated = PlanBuilder.getInstance()
+            .withStatus(CrisprProductionPlanState.PlanCreated.getInternalName())
+            .withAttemptType(AttemptTypes.CRISPR.getTypeName())
+            .build();
+        Plan planWithAttemptInProgress = PlanBuilder.getInstance()
+            .withStatus(CrisprProductionPlanState.AttemptInProgress.getInternalName())
+            .withAttemptType(AttemptTypes.CRISPR.getTypeName())
+            .build();
+        Plan planWithEmbryosObtained = PlanBuilder.getInstance()
+            .withStatus(CrisprProductionPlanState.EmbryosObtained.getInternalName())
+            .withAttemptType(AttemptTypes.CRISPR.getTypeName())
+            .build();
+
+        PlanStateMachineResolver planStateMachineResolver = new PlanStateMachineResolver();
+        testInstance.setStateMachineResolver(planStateMachineResolver);
+        when(stateTransitionsManager.processEvent(any(Plan.class)))
+            .thenReturn(planWithAttemptInProgress, planWithEmbryosObtained);
+
+        testInstance.execute(planCreated);
+
+        verify(stateTransitionsManager, times(3)).processEvent(any(Plan.class));
+        assertThat(
+            "Not expected status",
+            planCreated.getStatus().getName(),
+            is(CrisprProductionPlanState.EmbryosObtained.getInternalName()));
+    }
+
+    @Test
+    public void testExceptionWhenStateTransitionsManagerNull()
+    {
+        SystemOperationFailedException thrown = assertThrows(SystemOperationFailedException.class,
+            () -> testInstance.execute(new Plan()),
+            "Exception not thrown");
+        assertThat(
+            "Not expected message",
+            thrown.getDebugMessage(),
+            is("System triggered transitions could not be executed"));
+    }
+
+    @Test
+    public void testExceptionWhenUserTransitionPresent()
+    {
+        Plan planCreated = PlanBuilder.getInstance()
+            .withStatus(CrisprProductionPlanState.PlanCreated.getInternalName())
+            .withAttemptType(AttemptTypes.CRISPR.getTypeName())
+            .build();
+        Plan planWithAttemptInProgress = PlanBuilder.getInstance()
+            .withStatus(CrisprProductionPlanState.AttemptInProgress.getInternalName())
+            .withAttemptType(AttemptTypes.CRISPR.getTypeName())
+            .build();
+
+        testInstance.setStateMachineResolver(planStateMachineResolver);
+        when(stateTransitionsManager.processEvent(any(Plan.class)))
+            .thenReturn(planWithAttemptInProgress);
+
+        planCreated.setEvent(CrisprProductionPlanEvent.abortWhenCreated);
+
+        UserOperationFailedException thrown = assertThrows(UserOperationFailedException.class,
+            () -> testInstance.execute(planCreated),
+            "Exception not thrown");
+        assertThat(
+            "Not expected message",
+            thrown.getMessage(),
+            is("Trying to execute action [abortWhenCreated] but also modifying data that causes a change in status. " +
+                "Please do this in two different steps."));
+    }
+}

--- a/impc_prod_tracker/rest-api/src/main/java/org/gentar/biology/plan/PlanMapper.java
+++ b/impc_prod_tracker/rest-api/src/main/java/org/gentar/biology/plan/PlanMapper.java
@@ -12,9 +12,6 @@ import org.gentar.biology.plan.status.PlanStatusStamp;
 import org.gentar.biology.plan.type.PlanType;
 import org.gentar.biology.plan.type.PlanTypes;
 import org.gentar.biology.project.*;
-import org.gentar.biology.status.Status;
-import org.gentar.biology.status.StatusMapper;
-import org.gentar.biology.status.StatusNames;
 import org.gentar.biology.status_stamps.StatusStampsDTO;
 import org.gentar.common.state_machine.StatusTransitionDTO;
 import org.gentar.common.state_machine.TransitionDTO;
@@ -43,7 +40,6 @@ public class PlanMapper implements Mapper<Plan, PlanDTO>
     private FunderMapper funderMapper;
     private WorkUnitMapper workUnitMapper;
     private WorkGroupMapper workGroupMapper;
-    private StatusMapper statusMapper;
     private PlanTypeMapper planTypeMapper;
     private ProjectService projectService;
     private PlanStateMachineResolver planStateMachineResolver;
@@ -57,7 +53,6 @@ public class PlanMapper implements Mapper<Plan, PlanDTO>
         FunderMapper funderMapper,
         WorkUnitMapper workUnitMapper,
         WorkGroupMapper workGroupMapper,
-        StatusMapper statusMapper,
         PlanTypeMapper planTypeMapper,
         ProjectService projectService,
         PlanStateMachineResolver planStateMachineResolver,
@@ -70,7 +65,6 @@ public class PlanMapper implements Mapper<Plan, PlanDTO>
         this.funderMapper = funderMapper;
         this.workUnitMapper = workUnitMapper;
         this.workGroupMapper = workGroupMapper;
-        this.statusMapper = statusMapper;
         this.planTypeMapper = planTypeMapper;
         this.projectService = projectService;
         this.planStateMachineResolver = planStateMachineResolver;
@@ -145,17 +139,7 @@ public class PlanMapper implements Mapper<Plan, PlanDTO>
         setCrisprAttempt(plan, planDTO);
         setPlanType(plan, planDTO);
         setAttemptType(plan, planDTO);
-        setStatusAndSummaryStatus(plan);
-        plan.setSummaryStatus(statusMapper.toEntity(StatusNames.PLAN_CREATED));
-
         return plan;
-    }
-
-    private void setStatusAndSummaryStatus(Plan plan)
-    {
-        Status planCreatedStatus = statusMapper.toEntity(StatusNames.PLAN_CREATED);
-        plan.setStatus(planCreatedStatus);
-        plan.setSummaryStatus(planCreatedStatus);
     }
 
     private void setAttemptType(Plan plan, PlanDTO planDTO)
@@ -198,7 +182,7 @@ public class PlanMapper implements Mapper<Plan, PlanDTO>
     private List<TransitionDTO> getTransitionsByPlanType(Plan plan)
     {
         List<ProcessEvent> transitions =
-            planStateMachineResolver.getAvailableTransitionsByPlanStatus(plan);
+            planStateMachineResolver.getAvailableTransitionsByEntityStatus(plan);
         return transitionMapper.toDtos(transitions);
     }
 }

--- a/impc_prod_tracker/rest-api/src/main/java/org/gentar/biology/plan/attempt/crispr/AssayMapper.java
+++ b/impc_prod_tracker/rest-api/src/main/java/org/gentar/biology/plan/attempt/crispr/AssayMapper.java
@@ -44,13 +44,15 @@ public class AssayMapper implements Mapper<Assay, AssayDTO>
     public Assay toEntity(AssayDTO assayDTO)
     {
         Assay assay = entityMapper.toTarget(assayDTO, Assay.class);
-        String assayTypeName = assayDTO.getTypeName();
-        if (assayTypeName != null)
+        if (assay != null)
         {
-            AssayType assayType = crisprAttemptService.getAssayTypeByName(assayTypeName);
-            assay.setAssayType(assayType);
+            String assayTypeName = assayDTO.getTypeName();
+            if (assayTypeName != null)
+            {
+                AssayType assayType = crisprAttemptService.getAssayTypeByName(assayTypeName);
+                assay.setAssayType(assayType);
+            }
         }
-
         return assay;
     }
 }

--- a/impc_prod_tracker/rest-api/src/main/java/org/gentar/biology/plan/attempt/crispr/CrisprAttemptMapper.java
+++ b/impc_prod_tracker/rest-api/src/main/java/org/gentar/biology/plan/attempt/crispr/CrisprAttemptMapper.java
@@ -81,7 +81,7 @@ public class CrisprAttemptMapper implements Mapper<CrisprAttempt, CrisprAttemptD
     public CrisprAttempt toEntity(CrisprAttemptDTO crisprAttemptDTO)
     {
         CrisprAttempt crisprAttempt = modelMapper.map(crisprAttemptDTO, CrisprAttempt.class);
-        setAssayType(crisprAttempt, crisprAttemptDTO);
+        setAssay(crisprAttempt, crisprAttemptDTO);
         setStrain(crisprAttempt, crisprAttemptDTO);
         setGuidesToEntity(crisprAttempt, crisprAttemptDTO);
         setGenotypePrimersToEntity(crisprAttempt, crisprAttemptDTO);
@@ -91,10 +91,13 @@ public class CrisprAttemptMapper implements Mapper<CrisprAttempt, CrisprAttemptD
         return crisprAttempt;
     }
 
-    private void setAssayType(CrisprAttempt crisprAttempt, CrisprAttemptDTO crisprAttemptDTO)
+    private void setAssay(CrisprAttempt crisprAttempt, CrisprAttemptDTO crisprAttemptDTO)
     {
         Assay assay = assayMapper.toEntity(crisprAttemptDTO.getAssay());
-        assay.setCrisprAttempt(crisprAttempt);
+        if (assay != null)
+        {
+            assay.setCrisprAttempt(crisprAttempt);
+        }
         crisprAttempt.setAssay(assay);
     }
 


### PR DESCRIPTION
- Automatic execution of system triggered transitions for plan.
- Added class to set the right summary status of a plan based on the statuses of its children.
- Using the logic to assign the summary status of a plan when it's created.
- Create processor to move crispr from Plan Created to Attempt in Progress
- Fixing NPE when creating plans with crispr attempt without assay.