### PR TITLE
Summary status assignation to project and Plan#459

### DIFF
--- a/impc_prod_tracker/core/src/main/java/org/gentar/biology/plan/engine/events/CrisprProductionPlanEvent.java
+++ b/impc_prod_tracker/core/src/main/java/org/gentar/biology/plan/engine/events/CrisprProductionPlanEvent.java
@@ -9,7 +9,6 @@ import org.gentar.statemachine.ProcessEvent;
 import org.gentar.statemachine.ProcessState;
 import org.gentar.statemachine.Processor;
 import org.gentar.statemachine.StateMachineConstants;
-
 import java.util.Arrays;
 import java.util.List;
 

--- a/impc_prod_tracker/core/src/main/java/org/gentar/biology/plan/engine/processors/crispr/CrisprPlanAttemptInProgressProcessor.java
+++ b/impc_prod_tracker/core/src/main/java/org/gentar/biology/plan/engine/processors/crispr/CrisprPlanAttemptInProgressProcessor.java
@@ -2,44 +2,22 @@ package org.gentar.biology.plan.engine.processors.crispr;
 
 import org.gentar.biology.plan.Plan;
 import org.gentar.biology.plan.engine.PlanStateSetter;
-import org.gentar.biology.plan.engine.state.CrisprProductionPlanState;
+import org.gentar.statemachine.AbstractProcessor;
 import org.gentar.statemachine.ProcessData;
-import org.gentar.statemachine.ProcessEvent;
-import org.gentar.statemachine.ProcessState;
-import org.gentar.statemachine.Processor;
 import org.springframework.stereotype.Component;
 
 @Component
-public class CrisprPlanAttemptInProgressProcessor implements Processor
+public class CrisprPlanAttemptInProgressProcessor extends AbstractProcessor
 {
-    private PlanStateSetter planStateSetter;
-
     public CrisprPlanAttemptInProgressProcessor(PlanStateSetter planStateSetter)
     {
-        this.planStateSetter = planStateSetter;
+        super(planStateSetter);
     }
 
     @Override
-    public ProcessData process(ProcessData data)
+    protected boolean canExecuteTransition(ProcessData entity)
     {
-        tryToMoveToAttemptInProgress((Plan)data);
-        return data;
-    }
-
-    private void tryToMoveToAttemptInProgress(Plan plan)
-    {
-        if (canMoveToAttemptInProgress(plan))
-        {
-            ProcessEvent processEvent = plan.getEvent();
-            ProcessState endState = processEvent.getEndState();
-            assert(endState.equals(CrisprProductionPlanState.AttemptInProgress));
-            String statusName = endState.getInternalName();
-            planStateSetter.setStatusByName(plan, statusName);
-        }
-    }
-
-    private boolean canMoveToAttemptInProgress(Plan plan)
-    {
+        Plan plan = (Plan)entity;
         return plan.getCrisprAttempt() != null;
     }
 }

--- a/impc_prod_tracker/core/src/main/java/org/gentar/statemachine/AbstractProcessor.java
+++ b/impc_prod_tracker/core/src/main/java/org/gentar/statemachine/AbstractProcessor.java
@@ -1,0 +1,79 @@
+package org.gentar.statemachine;
+
+import lombok.Data;
+import org.gentar.exceptions.SystemOperationFailedException;
+
+/**
+ * Define the abstract methods for a processor: the logic to change state in a state machine.
+ */
+@Data
+public abstract class AbstractProcessor implements Processor
+{
+    private StateSetter stateSetter;
+    private static final String TRANSITION_ERROR =
+        "Transition [%s] cannot be executed because it goes from status [%s] to [%s] but current" +
+            " status in the entity [%s] is [%s]";
+
+    protected AbstractProcessor(StateSetter stateSetter)
+    {
+        this.stateSetter = stateSetter;
+    }
+
+    @Override
+    public ProcessData process(ProcessData entity)
+    {
+        checkEntityIsNotNull(entity);
+        tryToExecuteTransition(entity);
+        return entity;
+    }
+
+    private void checkEntityIsNotNull(ProcessData entity)
+    {
+        if (entity == null)
+        {
+            throw new SystemOperationFailedException(
+                "State Machine cannot be executed", "Entity is null");
+        }
+    }
+
+    private void tryToExecuteTransition(ProcessData entity)
+    {
+        if (canExecuteTransition(entity))
+        {
+            ProcessEvent processEvent = entity.getEvent();
+            if (processEvent != null)
+            {
+                ProcessState endState = getValidatedEndState(entity, processEvent);
+                String statusName = endState.getInternalName();
+                stateSetter.setStatusByName(entity, statusName);
+            }
+        }
+    }
+
+    private ProcessState getValidatedEndState(ProcessData entity, ProcessEvent transition)
+    {
+        String currentStatusName = entity.getStatus().getName();
+        String initialStatusTransitionName = transition.getInitialState().getInternalName();
+        if (!currentStatusName.equals(initialStatusTransitionName))
+        {
+            throw new SystemOperationFailedException(
+                "Invalid transition",
+                String.format(
+                    TRANSITION_ERROR,
+                    transition.getName(),
+                    transition.getInitialState().getInternalName(),
+                    transition.getEndState().getInternalName(),
+                    entity.getClass().getSimpleName(),
+                    entity.getStatus().getName()
+                    ));
+        }
+        return transition.getEndState();
+    }
+
+    /**
+     * Each concrete processor has to define the logic to decide if a transition can be done or not.
+     * @param entity Entity to be processed.
+     * @return True if the transition can be executed. False if not.
+     */
+    protected abstract boolean canExecuteTransition(ProcessData entity);
+}

--- a/impc_prod_tracker/core/src/test/java/org/gentar/biology/plan/engine/processors/crispr/CrisprPlanAttemptInProgressProcessorTest.java
+++ b/impc_prod_tracker/core/src/test/java/org/gentar/biology/plan/engine/processors/crispr/CrisprPlanAttemptInProgressProcessorTest.java
@@ -1,0 +1,59 @@
+package org.gentar.biology.plan.engine.processors.crispr;
+
+import org.gentar.biology.plan.Plan;
+import org.gentar.biology.plan.attempt.crispr.CrisprAttempt;
+import org.gentar.biology.plan.engine.PlanStateSetter;
+import org.gentar.biology.plan.engine.events.CrisprProductionPlanEvent;
+import org.gentar.biology.plan.engine.state.CrisprProductionPlanState;
+import org.gentar.test_util.PlanBuilder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class CrisprPlanAttemptInProgressProcessorTest
+{
+    private CrisprPlanAttemptInProgressProcessor testInstance;
+    @Mock
+    private PlanStateSetter planStateSetter;
+
+    @BeforeEach
+    public void setup()
+    {
+        testInstance = new CrisprPlanAttemptInProgressProcessor(planStateSetter);
+    }
+
+    @Test
+    public void testWhenNoAttempt()
+    {
+        testInstance.process(new Plan());
+
+        verify(planStateSetter, times(0)).setStatusByName(any(Plan.class), any(String.class));
+    }
+
+    @Test
+    public void testWhenAttempt()
+    {
+        Plan plan = PlanBuilder.getInstance()
+            .withStatus(CrisprProductionPlanState.PlanCreated.getInternalName())
+            .build();
+        CrisprAttempt crisprAttempt = new CrisprAttempt();
+        plan.setCrisprAttempt(crisprAttempt);
+        crisprAttempt.setPlan(plan);
+        plan.setEvent(CrisprProductionPlanEvent.changeToInProgress);
+
+        testInstance.process(plan);
+
+        verify(
+            planStateSetter,
+            times(1)).setStatusByName(any(Plan.class),
+            eq(CrisprProductionPlanEvent.changeToInProgress.getEndState().getInternalName()));
+    }
+}

--- a/impc_prod_tracker/core/src/test/java/org/gentar/statemachine/AbstractProcessorTest.java
+++ b/impc_prod_tracker/core/src/test/java/org/gentar/statemachine/AbstractProcessorTest.java
@@ -1,0 +1,124 @@
+package org.gentar.statemachine;
+
+import org.gentar.biology.plan.Plan;
+import org.gentar.biology.plan.engine.PlanStateSetter;
+import org.gentar.biology.plan.engine.events.CrisprProductionPlanEvent;
+import org.gentar.biology.plan.engine.state.CrisprProductionPlanState;
+import org.gentar.exceptions.SystemOperationFailedException;
+import org.gentar.test_util.PlanBuilder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AbstractProcessorTest
+{
+    private TestClass testInstance;
+
+    @Mock
+    private PlanStateSetter planStateSetter;
+
+    @BeforeEach
+    void setUp()
+    {
+        testInstance = new TestClass(planStateSetter);
+    }
+
+    @Test
+    public void testExceptionWhenNull()
+    {
+        SystemOperationFailedException thrown = assertThrows(SystemOperationFailedException.class,
+            () -> testInstance.process(null),
+            "Exception not thrown");
+        assertThat(
+            "Not expected message",
+            thrown.getExceptionDetail(),
+            is("Entity is null"));
+    }
+
+    @Test
+    public void testNoStatusChangeWhenEventIsNull()
+    {
+        Plan plan = new Plan();
+        plan.setEvent(null);
+
+        testInstance.process(plan);
+
+        verify(planStateSetter, times(0)).setStatusByName(any(Plan.class), any(String.class));
+    }
+
+    @Test
+    public void testNoStatusChangeWhenNoConditionsMet()
+    {
+        Plan plan = new Plan();
+        plan.setEvent(null);
+        testInstance = spy(testInstance);
+        when(testInstance.canExecuteTransition(any(Plan.class))).thenReturn(false);
+
+        testInstance.process(plan);
+
+        verify(planStateSetter, times(0)).setStatusByName(any(Plan.class), any(String.class));
+    }
+
+    @Test
+    public void testExceptionWhenIncorrectInitialStatus()
+    {
+        Plan plan = PlanBuilder.getInstance()
+            .withStatus(CrisprProductionPlanState.EmbryosObtained.getInternalName())
+            .build();
+        plan.setEvent(CrisprProductionPlanEvent.changeToInProgress);
+
+        SystemOperationFailedException thrown = assertThrows(SystemOperationFailedException.class,
+            () -> testInstance.process(plan),
+            "Exception not thrown");
+        assertThat(
+            "Not expected message",
+            thrown.getExceptionDetail(),
+            is("Transition [changeToInProgress] cannot be executed because it goes from status " +
+                "[Plan Created] to [Attempt In Progress] but current status in the entity [Plan]" +
+                " is [Embryos Obtained]"));
+    }
+
+    @Test
+    public void testStatusChangesWhenConditionsMet()
+    {
+        Plan plan = PlanBuilder.getInstance()
+            .withStatus(CrisprProductionPlanState.PlanCreated.getInternalName())
+            .build();
+        plan.setEvent(CrisprProductionPlanEvent.changeToInProgress);
+
+        testInstance.process(plan);
+
+        verify(
+            planStateSetter,
+            times(1)).setStatusByName(any(Plan.class),
+            eq(CrisprProductionPlanEvent.changeToInProgress.getEndState().getInternalName()));
+    }
+
+    static class TestClass extends AbstractProcessor
+    {
+
+        public TestClass(PlanStateSetter planStateSetter)
+        {
+            super(planStateSetter);
+        }
+
+        @Override
+        protected boolean canExecuteTransition(ProcessData entity)
+        {
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
- Create AbstractProcessor as the class that has the logic to set the status of an entity in a state machine, leaving the responsibility to the subclasses that extend from it to implement the logic to check if the transition can be executed or not.