### PR TITLE
Update only allowed fields in outcomes#524

### DIFF
--- a/impc_prod_tracker/core/src/main/java/org/gentar/biology/outcome/Outcome.java
+++ b/impc_prod_tracker/core/src/main/java/org/gentar/biology/outcome/Outcome.java
@@ -52,7 +52,7 @@ public class Outcome extends BaseEntity implements Resource<Outcome>
 
     @ToString.Exclude
     @EqualsAndHashCode.Exclude
-    @OneToMany(cascade = CascadeType.ALL, mappedBy = "outcome", orphanRemoval=true)
+    @OneToMany(cascade = CascadeType.ALL, mappedBy = "outcome")
     private Set<PlanStartingPoint> planStartingPoints;
 
     // Copy Constructor

--- a/impc_prod_tracker/core/src/main/java/org/gentar/biology/outcome/OutcomeCreator.java
+++ b/impc_prod_tracker/core/src/main/java/org/gentar/biology/outcome/OutcomeCreator.java
@@ -1,5 +1,8 @@
 package org.gentar.biology.outcome;
 
+import org.gentar.audit.history.History;
+import org.gentar.audit.history.HistoryService;
+import org.gentar.biology.plan.Plan;
 import org.springframework.stereotype.Component;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
@@ -14,11 +17,24 @@ class OutcomeCreator
 {
     @PersistenceContext
     private EntityManager entityManager;
+    private HistoryService<Outcome> historyService;
+
+    OutcomeCreator(HistoryService<Outcome> historyService)
+    {
+        this.historyService = historyService;
+    }
 
     public Outcome create(Outcome outcome)
     {
         Outcome createdOutcome = save(outcome);
+        registerCreationInHistory(createdOutcome);
         return createdOutcome;
+    }
+
+    private void registerCreationInHistory(Outcome outcome)
+    {
+        History history = historyService.buildCreationTrack(outcome, outcome.getId());
+        historyService.saveTrackOfChanges(history);
     }
 
     private Outcome save(Outcome outcome)

--- a/impc_prod_tracker/core/src/main/java/org/gentar/biology/outcome/OutcomeService.java
+++ b/impc_prod_tracker/core/src/main/java/org/gentar/biology/outcome/OutcomeService.java
@@ -2,7 +2,6 @@ package org.gentar.biology.outcome;
 
 import org.gentar.audit.history.History;
 import org.gentar.biology.outcome.type.OutcomeType;
-
 import java.util.List;
 
 /**
@@ -14,7 +13,6 @@ public interface OutcomeService
      * Find all the outcomes.
      * @return A list of {@link Outcome}
      */
-//    List<Outcome> findAll();
     List<Outcome> getOutcomes();
 
     /**

--- a/impc_prod_tracker/core/src/main/java/org/gentar/biology/outcome/OutcomeServiceImpl.java
+++ b/impc_prod_tracker/core/src/main/java/org/gentar/biology/outcome/OutcomeServiceImpl.java
@@ -10,6 +10,7 @@ import org.gentar.biology.status.StatusService;
 import org.gentar.exceptions.UserOperationFailedException;
 import org.gentar.security.abac.ResourceAccessChecker;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Collection;
 import java.util.List;
@@ -81,6 +82,7 @@ public class OutcomeServiceImpl implements OutcomeService
         }
     }
 
+    @Transactional
     public History update(Outcome outcome)
     {
         Outcome originalOutcome = new Outcome(getByTpoFailsIfNotFound(outcome.getTpo()));

--- a/impc_prod_tracker/core/src/main/java/org/gentar/biology/plan/PlanService.java
+++ b/impc_prod_tracker/core/src/main/java/org/gentar/biology/plan/PlanService.java
@@ -49,4 +49,6 @@ public interface PlanService
     List<History> getPlanHistory(Plan plan);
 
     Plan createPlan(Plan plan);
+
+    void updateStatusIfNeeded(Plan plan);
 }

--- a/impc_prod_tracker/core/src/main/java/org/gentar/biology/plan/PlanServiceImpl.java
+++ b/impc_prod_tracker/core/src/main/java/org/gentar/biology/plan/PlanServiceImpl.java
@@ -16,7 +16,6 @@
 package org.gentar.biology.plan;
 
 import org.gentar.biology.plan.engine.PlanCreator;
-import org.gentar.biology.project.Project;
 import org.gentar.exceptions.UserOperationFailedException;
 import org.gentar.audit.history.HistoryService;
 import org.gentar.security.abac.ResourceAccessChecker;
@@ -39,6 +38,7 @@ public class PlanServiceImpl implements PlanService
     private PlanUpdater planUpdater;
     private HistoryService historyService;
     private PlanCreator planCreator;
+    private PlanStatusManager planStatusManager;
 
     private static final String READ_PLAN_ACTION = "READ_PLAN";
     private static final String PLAN_NOT_EXISTS_ERROR =
@@ -49,13 +49,14 @@ public class PlanServiceImpl implements PlanService
         ResourceAccessChecker<Plan> resourceAccessChecker,
         PlanUpdater planUpdater,
         HistoryService historyService,
-        PlanCreator planCreator)
+        PlanCreator planCreator, PlanStatusManager planStatusManager)
     {
         this.planRepository = planRepository;
         this.resourceAccessChecker = resourceAccessChecker;
         this.planUpdater = planUpdater;
         this.historyService = historyService;
         this.planCreator = planCreator;
+        this.planStatusManager = planStatusManager;
     }
 
     @Override
@@ -138,5 +139,11 @@ public class PlanServiceImpl implements PlanService
     public Plan createPlan(Plan plan)
     {
         return planCreator.createPlan(plan);
+    }
+
+    @Override
+    public void updateStatusIfNeeded(Plan plan)
+    {
+        planStatusManager.updateStatusIfNeeded(plan);
     }
 }

--- a/impc_prod_tracker/core/src/main/java/org/gentar/biology/plan/status/PlanSummaryStatusUpdater.java
+++ b/impc_prod_tracker/core/src/main/java/org/gentar/biology/plan/status/PlanSummaryStatusUpdater.java
@@ -5,12 +5,8 @@ import org.gentar.biology.outcome.Outcome;
 import org.gentar.biology.plan.Plan;
 import org.gentar.biology.plan.attempt.phenotyping.PhenotypingAttempt;
 import org.gentar.biology.plan.attempt.phenotyping.stage.PhenotypingStage;
-import org.gentar.biology.project.Project;
-import org.gentar.biology.project.summary_status.ProjectSummaryStatusStamp;
 import org.gentar.biology.status.Status;
-import org.gentar.biology.status.StatusService;
 import org.springframework.stereotype.Component;
-
 import java.time.LocalDateTime;
 import java.util.*;
 
@@ -21,13 +17,6 @@ import java.util.*;
 @Component
 public class PlanSummaryStatusUpdater
 {
-    private StatusService statusService;
-
-    public PlanSummaryStatusUpdater(StatusService statusService)
-    {
-        this.statusService = statusService;
-    }
-
     public void setSummaryStatus(Plan plan)
     {
         List<Status> statuses = getChildrenStatus(plan);
@@ -39,7 +28,7 @@ public class PlanSummaryStatusUpdater
         setSummaryStatus(plan, mostAdvancedStatus);
     }
 
-    public List<Status> getChildrenStatus(Plan plan)
+    private List<Status> getChildrenStatus(Plan plan)
     {
         List<Status> statuses = new ArrayList<>();
         statuses.addAll(getOutcomesStatuses(plan));
@@ -47,7 +36,7 @@ public class PlanSummaryStatusUpdater
         return statuses;
     }
 
-    public List<Status> getOutcomesStatuses(Plan plan)
+    private List<Status> getOutcomesStatuses(Plan plan)
     {
         List<Status> outcomeStatuses = new ArrayList<>();
         Set<Outcome> outcomes = plan.getOutcomes();
@@ -55,16 +44,13 @@ public class PlanSummaryStatusUpdater
         {
             outcomes.forEach(x -> {
                 Colony colony = x.getColony();
-                if (colony != null)
-                {
-                    outcomeStatuses.add(colony.getStatus());
-                }
+                outcomeStatuses.add(colony.getStatus());
             });
         }
         return outcomeStatuses;
     }
 
-    public List<Status> getPhenotypingStagesStatuses(Plan plan)
+    private List<Status> getPhenotypingStagesStatuses(Plan plan)
     {
         List<Status> phenotypingStagesStatuses = new ArrayList<>();
         PhenotypingAttempt phenotypingAttempt = plan.getPhenotypingAttempt();

--- a/impc_prod_tracker/rest-api/src/main/java/org/gentar/biology/colony/ColonyMapper.java
+++ b/impc_prod_tracker/rest-api/src/main/java/org/gentar/biology/colony/ColonyMapper.java
@@ -12,7 +12,6 @@ import org.gentar.statemachine.EnumStateHelper;
 import org.gentar.statemachine.ProcessEvent;
 import org.gentar.statemachine.ProcessState;
 import org.springframework.stereotype.Component;
-
 import java.util.ArrayList;
 import java.util.List;
 

--- a/impc_prod_tracker/rest-api/src/main/java/org/gentar/biology/outcome/OutcomeMapper.java
+++ b/impc_prod_tracker/rest-api/src/main/java/org/gentar/biology/outcome/OutcomeMapper.java
@@ -8,16 +8,8 @@ import org.gentar.biology.mutation.MutationMapper;
 import org.gentar.biology.outcome.type.OutcomeType;
 import org.gentar.biology.plan.Plan;
 import org.gentar.biology.plan.PlanService;
-import org.gentar.biology.plan.attempt.phenotyping.PhenotypingStageDTO;
-import org.gentar.biology.plan.attempt.phenotyping.stage.PhenotypingStage;
-import org.gentar.biology.plan.attempt.phenotyping.stage.material_deposited_type.MaterialDepositedType;
 import org.gentar.biology.specimen.SpecimenMapper;
-import org.gentar.exceptions.UserOperationFailedException;
 import org.springframework.stereotype.Component;
-
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.Set;
 
 @Component
 public class OutcomeMapper implements Mapper<Outcome, OutcomeDTO>
@@ -82,30 +74,9 @@ public class OutcomeMapper implements Mapper<Outcome, OutcomeDTO>
         return outcome;
     }
 
-    @Override
-    public Set<Outcome> toEntities(Collection<OutcomeDTO> dtos) {
-        Set<Outcome> outcomes = new HashSet<>();
-        if (dtos != null)
-        {
-            dtos.forEach(outcomeDTO -> outcomes.add(toEntity(outcomeDTO)));
-        }
-
-        return outcomes;
-    }
-
     public Outcome toEntityBytTpo(String tpo)
     {
         Outcome outcome = outcomeService.getByTpoFailsIfNotFound(tpo);
         return outcome;
-    }
-
-    public Set<Outcome> toEntitiesBytTpo(Collection<String> tpos) {
-        Set<Outcome> outcomes = new HashSet<>();
-        if (tpos != null)
-        {
-            tpos.forEach(tpo -> outcomes.add(toEntityBytTpo(tpo)));
-        }
-
-        return outcomes;
     }
 }

--- a/impc_prod_tracker/rest-api/src/main/java/org/gentar/biology/plan/PlanMapper.java
+++ b/impc_prod_tracker/rest-api/src/main/java/org/gentar/biology/plan/PlanMapper.java
@@ -61,7 +61,8 @@ public class PlanMapper implements Mapper<Plan, PlanDTO>
     public PlanMapper(
         EntityMapper entityMapper,
         CrisprAttemptMapper crisprAttemptMapper,
-        BreedingAttemptMapper breedingAttemptMapper, PhenotypingAttemptMapper phenotypingAttemptMapper,
+        BreedingAttemptMapper breedingAttemptMapper,
+        PhenotypingAttemptMapper phenotypingAttemptMapper,
         AttemptTypeMapper attemptTypeMapper,
         FunderMapper funderMapper,
         WorkUnitMapper workUnitMapper,

--- a/impc_prod_tracker/rest-api/src/main/java/org/gentar/biology/strain/StrainMapper.java
+++ b/impc_prod_tracker/rest-api/src/main/java/org/gentar/biology/strain/StrainMapper.java
@@ -16,17 +16,12 @@
 package org.gentar.biology.strain;
 
 import org.gentar.Mapper;
-import org.gentar.biology.strain.StrainService;
-import org.gentar.exceptions.UserOperationFailedException;
 import org.springframework.stereotype.Component;
-import org.gentar.biology.strain.Strain;
 
 @Component
 public class StrainMapper implements Mapper<Strain, String>
 {
     private StrainService strainService;
-
-    private static final String STRAIN_NOT_FOUND_ERROR = "Strain '%s' does not exist.";
 
     public StrainMapper(StrainService strainService)
     {
@@ -46,13 +41,6 @@ public class StrainMapper implements Mapper<Strain, String>
 
     public Strain toEntity(String strainName)
     {
-        Strain strain = strainService.getStrainByName(strainName);
-
-        if (strain == null)
-        {
-            throw new UserOperationFailedException(String.format(STRAIN_NOT_FOUND_ERROR, strainName));
-        }
-
-        return strain;
+        return strainService.getStrainByNameFailWhenNotFound(strainName);
     }
 }


### PR DESCRIPTION
- Update plan status when outcome is updated.
- Register creation of outcome in history.
- Fix error when saving an outcome (bad starting point association).
- Make update of outcome transactional.