### PR TITLE
Update Colony state machine to reflect latest changes in design#529 

### DIFF
--- a/impc_prod_tracker/core/src/main/java/org/gentar/biology/colony/engine/processors/ReverseGenotypeConfirmationProcessor.java
+++ b/impc_prod_tracker/core/src/main/java/org/gentar/biology/colony/engine/processors/ReverseGenotypeConfirmationProcessor.java
@@ -2,6 +2,8 @@ package org.gentar.biology.colony.engine.processors;
 
 import org.gentar.biology.colony.Colony;
 import org.gentar.biology.colony.engine.ColonyStateSetter;
+import org.gentar.exceptions.UserOperationFailedException;
+import org.gentar.security.abac.spring.ContextAwarePolicyEnforcement;
 import org.gentar.statemachine.AbstractProcessor;
 import org.gentar.statemachine.ProcessData;
 import org.gentar.statemachine.ProcessEvent;
@@ -11,9 +13,13 @@ import org.springframework.stereotype.Component;
 @Component
 public class ReverseGenotypeConfirmationProcessor extends AbstractProcessor
 {
-    public ReverseGenotypeConfirmationProcessor(ColonyStateSetter colonyStateSetter)
+    private ContextAwarePolicyEnforcement policyEnforcement;
+
+    public ReverseGenotypeConfirmationProcessor(
+        ColonyStateSetter colonyStateSetter, ContextAwarePolicyEnforcement policyEnforcement)
     {
         super(colonyStateSetter);
+        this.policyEnforcement = policyEnforcement;
     }
 
     @Override
@@ -32,7 +38,6 @@ public class ReverseGenotypeConfirmationProcessor extends AbstractProcessor
 
     public boolean canExecuteTransition(Colony colony)
     {
-        // TODO: Can be done only by CDA or DCC
-        return false;
+        return policyEnforcement.hasPermission(colony, "REVERSE_GENOTYPE_CONFIRMATION");
     }
 }

--- a/impc_prod_tracker/core/src/main/java/org/gentar/biology/colony/engine/processors/ReverseGenotypeConfirmationProcessor.java
+++ b/impc_prod_tracker/core/src/main/java/org/gentar/biology/colony/engine/processors/ReverseGenotypeConfirmationProcessor.java
@@ -2,7 +2,6 @@ package org.gentar.biology.colony.engine.processors;
 
 import org.gentar.biology.colony.Colony;
 import org.gentar.biology.colony.engine.ColonyStateSetter;
-import org.gentar.exceptions.UserOperationFailedException;
 import org.gentar.security.abac.spring.ContextAwarePolicyEnforcement;
 import org.gentar.statemachine.AbstractProcessor;
 import org.gentar.statemachine.ProcessData;

--- a/impc_prod_tracker/core/src/main/java/org/gentar/security/abac/subject/AapSystemSubject.java
+++ b/impc_prod_tracker/core/src/main/java/org/gentar/security/abac/subject/AapSystemSubject.java
@@ -294,7 +294,7 @@ public class AapSystemSubject implements SystemSubject
 
         if (configuredLogin != null)
         {
-            result = login.equals(configuredLogin);
+            result = person.getEmail().equals(configuredLogin);
         }
 
         return result;


### PR DESCRIPTION
- Restrict reversion of genotype confirmation to CDA and DCC.