### PR TITLE
Packaging the documentation

### DIFF
--- a/impc_prod_tracker/rest-api/pom.xml
+++ b/impc_prod_tracker/rest-api/pom.xml
@@ -246,6 +246,32 @@
 					</dependency>
 				</dependencies>
 			</plugin>
+
+            <!--This is to package the documentation-->
+			<plugin>
+				<artifactId>maven-resources-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>copy-resources</id>
+						<phase>prepare-package</phase>
+						<goals>
+							<goal>copy-resources</goal>
+						</goals>
+						<configuration>
+							<outputDirectory>
+								${project.build.outputDirectory}/static/docs
+							</outputDirectory>
+							<resources>
+								<resource>
+									<directory>
+										${project.build.directory}/generated-docs
+									</directory>
+								</resource>
+							</resources>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
 


### PR DESCRIPTION
Using instructions from https://docs.spring.io/spring-restdocs/docs/1.2.6.RELEASE/reference/html5/#getting-started-build-configuration-maven-packaging