### PR TITLE
Update public API documentation to be concurrent with new development…

### DIFF
--- a/impc_prod_tracker/rest-api/src/main/java/org/gentar/biology/project/ProjectController.java
+++ b/impc_prod_tracker/rest-api/src/main/java/org/gentar/biology/project/ProjectController.java
@@ -223,7 +223,7 @@ class ProjectController
 
     private ProjectResponseDTO getDTO(Project project)
     {
-        ProjectResponseDTO projectResponseDTO = new ProjectResponseDTO();
+        ProjectResponseDTO projectResponseDTO = null;
         if (project != null)
         {
             projectResponseDTO = projectResponseMapper.toDto(project);

--- a/impc_prod_tracker/rest-api/src/main/java/org/gentar/biology/species/SpeciesMapper.java
+++ b/impc_prod_tracker/rest-api/src/main/java/org/gentar/biology/species/SpeciesMapper.java
@@ -3,8 +3,6 @@ package org.gentar.biology.species;
 import org.gentar.Mapper;
 import org.gentar.exceptions.UserOperationFailedException;
 import org.springframework.stereotype.Component;
-import java.util.Collection;
-import java.util.List;
 
 @Component
 public class SpeciesMapper implements Mapper<Species, String>
@@ -19,13 +17,14 @@ public class SpeciesMapper implements Mapper<Species, String>
     }
 
     @Override
-    public String toDto(Species entity) {
-        return null;
-    }
-
-    @Override
-    public List<String> toDtos(Collection<Species> entities) {
-        return null;
+    public String toDto(Species species)
+    {
+        String speciesName = null;
+        if (species != null)
+        {
+            speciesName = species.getName();
+        }
+        return speciesName;
     }
 
     @Override

--- a/impc_prod_tracker/rest-api/src/test/java/org/gentar/biology/species/SpeciesMapperTest.java
+++ b/impc_prod_tracker/rest-api/src/test/java/org/gentar/biology/species/SpeciesMapperTest.java
@@ -1,0 +1,54 @@
+package org.gentar.biology.species;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class SpeciesMapperTest
+{
+    public static final String SPECIES_NAME = "speciesName";
+    private SpeciesMapper testInstance;
+
+    @Mock
+    private SpeciesService speciesService;
+
+    @BeforeEach
+    void setUp()
+    {
+        testInstance = new SpeciesMapper(speciesService);
+    }
+
+    @Test
+    void toDto()
+    {
+        Species species = new Species();
+        species.setName(SPECIES_NAME);
+
+        String speciesName = testInstance.toDto(species);
+
+        assertThat(speciesName, is(SPECIES_NAME));
+    }
+
+    @Test
+    void toEntity()
+    {
+        String speciesName = SPECIES_NAME;
+        Species expectedResult = new Species();
+        expectedResult.setName(SPECIES_NAME);
+        when(speciesService.getSpeciesByName(speciesName)).thenReturn(expectedResult);
+
+        Species result = testInstance.toEntity(speciesName);
+
+        verify(speciesService, times(1)).getSpeciesByName(speciesName);
+        assertThat(result.getName(), is(SPECIES_NAME));
+    }
+}

--- a/impc_prod_tracker/rest-api/src/test/java/org/gentar/framework/db/Paths.java
+++ b/impc_prod_tracker/rest-api/src/test/java/org/gentar/framework/db/Paths.java
@@ -2,5 +2,6 @@ package org.gentar.framework.db;
 
 public class Paths
 {
+    public final static String CREATE_USER = "/dbunit/auth/createUser.xml";
     public final static String MULTIPLE_PROJECTS = "/dbunit/projects/multipleProjects.xml";
 }

--- a/impc_prod_tracker/rest-api/src/test/java/org/gentar/web/controller/auth/AuthControllerTest.java
+++ b/impc_prod_tracker/rest-api/src/test/java/org/gentar/web/controller/auth/AuthControllerTest.java
@@ -15,8 +15,11 @@
  */
 package org.gentar.web.controller.auth;
 
+import com.github.springtestdbunit.annotation.DatabaseOperation;
 import com.github.springtestdbunit.annotation.DatabaseSetup;
+import com.github.springtestdbunit.annotation.DatabaseTearDown;
 import org.gentar.framework.ControllerTestTemplate;
+import org.gentar.framework.db.Paths;
 import org.gentar.security.auth.AuthenticationRequest;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
@@ -36,7 +39,8 @@ public class AuthControllerTest extends ControllerTestTemplate
         "Invalid User/Password provided.";
 
     @Test
-    @DatabaseSetup("/dbunit/auth/createUser.xml")
+    @DatabaseSetup(Paths.CREATE_USER)
+    @DatabaseTearDown(type = DatabaseOperation.DELETE_ALL, value = Paths.CREATE_USER)
     public void testSignIn() throws Exception
     {
         AuthenticationRequest authenticationRequest =

--- a/impc_prod_tracker/rest-api/src/test/java/org/gentar/web/controller/project/ProjectControllerTest.java
+++ b/impc_prod_tracker/rest-api/src/test/java/org/gentar/web/controller/project/ProjectControllerTest.java
@@ -7,6 +7,7 @@ import org.gentar.biology.plan.PlanMinimumCreationDTO;
 import org.gentar.biology.project.ProjectCommonDataDTO;
 import org.gentar.biology.project.ProjectCreationDTO;
 import org.gentar.biology.project.ProjectDTO;
+import org.gentar.biology.project.ProjectResponseDTO;
 import org.gentar.framework.ControllerTestTemplate;
 import org.gentar.framework.db.Paths;
 import org.gentar.util.JsonHelper;
@@ -39,11 +40,28 @@ class ProjectControllerTest extends ControllerTestTemplate
     @DatabaseSetup(Paths.MULTIPLE_PROJECTS)
     void testGetOneProject() throws Exception
     {
-        mvc().perform(MockMvcRequestBuilders
+        ResultActions resultActions = mvc().perform(MockMvcRequestBuilders
             .get("/api/projects/TPN:01")
             .header("Authorization", accessToken))
             .andExpect(status().isOk())
             .andDo(documentSingleProject());
+
+        MvcResult result = resultActions.andReturn();
+        String contentAsString = result.getResponse().getContentAsString();
+        ProjectResponseDTO projectResponseDTO =
+            JsonHelper.fromJson(contentAsString, ProjectResponseDTO.class);
+        System.out.println(projectResponseDTO);
+        assertThat(projectResponseDTO.getTpn(), is("TPN:01"));
+    }
+
+    @Test
+    @DatabaseSetup(Paths.MULTIPLE_PROJECTS)
+    void testGetOneProjectNotExisting() throws Exception
+    {
+        mvc().perform(MockMvcRequestBuilders
+            .get("/api/projects/TPN:01X")
+            .header("Authorization", accessToken))
+            .andExpect(status().is5xxServerError());
     }
 
     private ResultHandler documentSingleProject()
@@ -79,6 +97,10 @@ class ProjectControllerTest extends ControllerTestTemplate
                     .description("Species associated with the project."),
                 fieldWithPath("consortia")
                     .description("Consortia associated with the project."),
+                fieldWithPath("consortia[].consortiumName")
+                    .description("Name of the consortium."),
+                fieldWithPath("consortia[].institutes")
+                    .description("Institutes associated with the project - consortium"),
                 fieldWithPath("_links")
                     .description("Links for project"),
                 fieldWithPath("_links.productionPlans")

--- a/impc_prod_tracker/rest-api/src/test/java/org/gentar/web/controller/project/ProjectControllerTest.java
+++ b/impc_prod_tracker/rest-api/src/test/java/org/gentar/web/controller/project/ProjectControllerTest.java
@@ -1,6 +1,8 @@
 package org.gentar.web.controller.project;
 
+import com.github.springtestdbunit.annotation.DatabaseOperation;
 import com.github.springtestdbunit.annotation.DatabaseSetup;
+import com.github.springtestdbunit.annotation.DatabaseTearDown;
 import org.gentar.biology.plan.PlanCommonDataDTO;
 import org.gentar.biology.plan.PlanDTO;
 import org.gentar.biology.plan.PlanMinimumCreationDTO;
@@ -38,6 +40,7 @@ class ProjectControllerTest extends ControllerTestTemplate
 
     @Test
     @DatabaseSetup(Paths.MULTIPLE_PROJECTS)
+    @DatabaseTearDown(type = DatabaseOperation.DELETE_ALL, value = Paths.MULTIPLE_PROJECTS)
     void testGetOneProject() throws Exception
     {
         ResultActions resultActions = mvc().perform(MockMvcRequestBuilders
@@ -56,6 +59,7 @@ class ProjectControllerTest extends ControllerTestTemplate
 
     @Test
     @DatabaseSetup(Paths.MULTIPLE_PROJECTS)
+    @DatabaseTearDown(type = DatabaseOperation.DELETE_ALL, value = Paths.MULTIPLE_PROJECTS)
     void testGetOneProjectNotExisting() throws Exception
     {
         mvc().perform(MockMvcRequestBuilders
@@ -112,6 +116,7 @@ class ProjectControllerTest extends ControllerTestTemplate
 
     @Test
     @DatabaseSetup(Paths.MULTIPLE_PROJECTS)
+    @DatabaseTearDown(type = DatabaseOperation.DELETE_ALL, value = Paths.MULTIPLE_PROJECTS)
     void testGetAllProjects() throws Exception
     {
         mvc().perform(MockMvcRequestBuilders
@@ -123,6 +128,7 @@ class ProjectControllerTest extends ControllerTestTemplate
 
     @Test
     @DatabaseSetup(Paths.MULTIPLE_PROJECTS)
+    @DatabaseTearDown(type = DatabaseOperation.DELETE_ALL, value = Paths.MULTIPLE_PROJECTS)
     void testGetAllProjectsWithFilter() throws Exception
     {
         mvc().perform(MockMvcRequestBuilders

--- a/impc_prod_tracker/rest-api/src/test/resources/dbunit/auth/createUser.xml
+++ b/impc_prod_tracker/rest-api/src/test/resources/dbunit/auth/createUser.xml
@@ -1,36 +1,38 @@
 <dataset>
-    <role
+    <ROLE
             id="1"
             name="general"
     />
-    <work_unit
+    <WORK_UNIT
             id="1"
             name="UCD"
     />
-    <consortium
+    <CONSORTIUM
             id="1"
             name="BaSH"
     />
-    <institute
+    <INSTITUTE
             id="1"
             name="Yale"
     />
-    <person
+    
+    <PERSON
             id="1"
             email="imits2test@test.com"
             auth_id="usr-dde67fbd-c3c2-42eb-aa81-f1a225f047c7"
     />
-    <person_role_work_unit
+    <PERSON_ROLE_WORK_UNIT
             id="1"
             person_id="1"
             role_id="1"
             work_unit_id="1"
     />
-    <person_role_consortium
+    <PERSON_ROLE_CONSORTIUM
             id="1"
             person_id="1"
             role_id="1"
             consortium_id="1"
     />
+    <PROJECT_CONSORTIUM_INSTITUTE/>
 
 </dataset>

--- a/impc_prod_tracker/rest-api/src/test/resources/dbunit/projects/multipleProjects.xml
+++ b/impc_prod_tracker/rest-api/src/test/resources/dbunit/projects/multipleProjects.xml
@@ -6,6 +6,12 @@
     <PRIVACY    ID="3"
                 NAME="restricted"/>
 
+    <SPECIES    ID="1"
+                NAME="Mus musculus"/>
+    <SPECIES    ID="2"
+                NAME="Homo sapiens"/>
+
+
     <ASSIGNMENT_STATUS  ID="1"
                         NAME="Assigned"/>
     <ASSIGNMENT_STATUS  ID="2"
@@ -41,11 +47,22 @@
     <STATUS     ID="2"
                 NAME="Attempt In Progress"/>
 
+    <CONSORTIUM ID="1"
+                NAME="CMG"/>
+
+    <INSTITUTE  ID="1"
+                NAME="Broad"/>
+    <INSTITUTE  ID="2"
+                NAME="Yale"/>
+
     <PROJECT    ID="101"
                 TPN="TPN:01"
                 PRIVACY_ID="1"
                 ASSIGNMENT_STATUS_ID="1"
-                SUMMARY_STATUS_ID="1"/>
+                SUMMARY_STATUS_ID="1"
+                RECOVERY="false"
+                COMMENT="Comment test"
+                PROJECT_EXTERNAL_REF="External reference 01"/>
     <PROJECT    ID="102"
                 TPN="TPN:02"
                 PRIVACY_ID="1"
@@ -72,7 +89,39 @@
                 PROJECT_ID="101"
                 PLAN_TYPE_ID="1"
                 STATUS_ID="1"
+                WORK_UNIT_ID="1"
+                WORK_GROUP_ID="1"
                 SUMMARY_STATUS_ID="1"/>
+
+    <PROJECT_SPECIES    PROJECT_ID="101"
+                        SPECIES_ID="1"/>
+    <PROJECT_SPECIES    PROJECT_ID="102"
+                        SPECIES_ID="2"/>
+
+    <PROJECT_CONSORTIUM ID="1"
+                        PROJECT_ID="101"
+                        CONSORTIUM_ID="1"/>
+    <PROJECT_CONSORTIUM ID="2"
+                        PROJECT_ID="102"
+                        CONSORTIUM_ID="1"/>
+    <PROJECT_CONSORTIUM ID="3"
+                        PROJECT_ID="103"
+                        CONSORTIUM_ID="1"/>
+    <PROJECT_CONSORTIUM ID="4"
+                        PROJECT_ID="104"
+                        CONSORTIUM_ID="1"/>
+    <PROJECT_CONSORTIUM ID="5"
+                        PROJECT_ID="105"
+                        CONSORTIUM_ID="1"/>
+
+    <PROJECT_CONSORTIUM_INSTITUTE   PROJECT_CONSORTIUM_ID="1"
+                                    INSTITUTE_ID="1"/>
+    <PROJECT_CONSORTIUM_INSTITUTE   PROJECT_CONSORTIUM_ID="1"
+                                    INSTITUTE_ID="2"/>
+    <PROJECT_CONSORTIUM_INSTITUTE   PROJECT_CONSORTIUM_ID="2"
+                                    INSTITUTE_ID="1"/>
+    <PROJECT_CONSORTIUM_INSTITUTE   PROJECT_CONSORTIUM_ID="3"
+                                    INSTITUTE_ID="2"/>
 
     <PERSON     ID="123"
                 EMAIL="imits2test@test.com"


### PR DESCRIPTION
Update public API documentation to be concurrent with new development

- Adding more documentation data to get a specific project endpoint.
- Fixing species mapper and adding test to it.
- Making get a specific project endpoint fail if project does not exist. Add integration test to check that.