### PR TITLE
Create dedicated DTOs for create, update and get plans#578

### DIFF
--- a/impc_prod_tracker/core/src/main/java/org/gentar/biology/plan/Plan.java
+++ b/impc_prod_tracker/core/src/main/java/org/gentar/biology/plan/Plan.java
@@ -155,7 +155,12 @@ public class Plan extends BaseEntity implements Resource<Plan>, ProcessData
         this.productsAvailableForGeneralPublic = plan.productsAvailableForGeneralPublic;
         this.planFlags = new HashSet<>(plan.planFlags);
         this.protocols = new HashSet<>(plan.protocols);
-        this.planStatusStamps = new HashSet<>(plan.planStatusStamps);
+        this.planStatusStamps =
+            plan.planStatusStamps == null ? null : new HashSet<>(plan.planStatusStamps);
+        this.planSummaryStatusStamps =
+            plan.planSummaryStatusStamps == null ? null : new HashSet<>(plan.planSummaryStatusStamps);
+        this.outcomes =
+            plan.outcomes == null ? null : new HashSet<>(plan.outcomes);
         this.status = plan.status;
         this.summaryStatus = plan.summaryStatus;
         this.attemptType = plan.attemptType;

--- a/impc_prod_tracker/core/src/main/java/org/gentar/statemachine/SystemEventsExecutor.java
+++ b/impc_prod_tracker/core/src/main/java/org/gentar/statemachine/SystemEventsExecutor.java
@@ -45,7 +45,7 @@ public class SystemEventsExecutor
     {
         originalEvent = entity.getEvent();
         executeNextTransitions(entity);
-        clearEvent(entity);
+        resetOriginalEvent(entity);
     }
 
     private void executeNextTransitions(ProcessData entity)
@@ -108,14 +108,9 @@ public class SystemEventsExecutor
         }
     }
 
-    // Remove any event set in this class
-    private void clearEvent(ProcessData entity)
+    // Set the original event the plan had before any system transition was performed.
+    private void resetOriginalEvent(ProcessData entity)
     {
-        String originalEventName = originalEvent == null ? "" : originalEvent.getName();
-        String lastEvent = entity.getEvent() == null ? "" : entity.getEvent().getName();
-        if (!originalEventName.equals(lastEvent))
-        {
-            entity.setEvent(null);
-        }
+        entity.setEvent(originalEvent);
     }
 }

--- a/impc_prod_tracker/dto/src/main/java/org/gentar/biology/plan/PlanBasicDataDTO.java
+++ b/impc_prod_tracker/dto/src/main/java/org/gentar/biology/plan/PlanBasicDataDTO.java
@@ -1,5 +1,6 @@
 package org.gentar.biology.plan;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
@@ -17,6 +18,10 @@ import java.util.List;
  */
 public class PlanBasicDataDTO
 {
+    @JsonIgnore
+    // Internal id useful keep the id accessible in all the plan DTOS.
+    private Long id;
+
     // Common information for all plan dtos.
     @JsonUnwrapped
     private PlanCommonDataDTO planCommonDataDTO;

--- a/impc_prod_tracker/dto/src/main/java/org/gentar/biology/plan/PlanResponseDTO.java
+++ b/impc_prod_tracker/dto/src/main/java/org/gentar/biology/plan/PlanResponseDTO.java
@@ -21,12 +21,12 @@ public class PlanResponseDTO extends RepresentationModel
     // Name of the status in the plan.
     private String statusName;
 
-    // Name of the summary status.
-    private String summaryStatusName;
-
     // List of stamps with all the different statuses this plan has had.
     @JsonProperty("statusDates")
     private List<StatusStampsDTO> statusStampsDTOS;
+
+    // Name of the summary status.
+    private String summaryStatusName;
 
     // List of stamps with all the different summary statuses this plan has had.
     @JsonProperty("summaryStatusDates")

--- a/impc_prod_tracker/dto/src/main/java/org/gentar/biology/plan/PlanUpdateDTO.java
+++ b/impc_prod_tracker/dto/src/main/java/org/gentar/biology/plan/PlanUpdateDTO.java
@@ -1,5 +1,6 @@
 package org.gentar.biology.plan;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
 import lombok.Data;
@@ -12,6 +13,10 @@ import org.gentar.common.state_machine.StatusTransitionDTO;
 @Data
 public class PlanUpdateDTO
 {
+    @JsonIgnore
+    // Internal id useful keep the id accessible in all the plan DTOS.
+    private Long id;
+
     // Public identifier for the plan.
     private String pin;
 

--- a/impc_prod_tracker/dto/src/test/java/org/gentar/biology/plan/PlanResponseDTOTest.java
+++ b/impc_prod_tracker/dto/src/test/java/org/gentar/biology/plan/PlanResponseDTOTest.java
@@ -7,7 +7,6 @@ import org.gentar.common.state_machine.StatusTransitionDTO;
 import org.gentar.common.state_machine.TransitionDTO;
 import org.junit.jupiter.api.Test;
 import org.util.JsonConverter;
-
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;

--- a/impc_prod_tracker/rest-api/src/main/java/org/gentar/biology/plan/PlanController.java
+++ b/impc_prod_tracker/rest-api/src/main/java/org/gentar/biology/plan/PlanController.java
@@ -21,7 +21,6 @@ import org.gentar.biology.ChangeResponse;
 import org.gentar.biology.plan.filter.PlanFilter;
 import org.gentar.biology.plan.filter.PlanFilterBuilder;
 import org.gentar.biology.plan.mappers.PlanCreationMapper;
-import org.gentar.biology.plan.mappers.PlanMapper;
 import org.gentar.biology.plan.mappers.PlanResponseMapper;
 import org.gentar.biology.project.ProjectService;
 import org.gentar.common.history.HistoryDTO;
@@ -54,7 +53,6 @@ public class PlanController
 {
     private HistoryMapper historyMapper;
     private PlanService planService;
-    private PlanMapper planMapper;
     private PlanCreationMapper planCreationMapper;
     private PlanResponseMapper planResponseMapper;
     private UpdatePlanRequestProcessor updatePlanRequestProcessor;
@@ -63,14 +61,13 @@ public class PlanController
     public PlanController(
         HistoryMapper historyMapper,
         PlanService planService,
-        PlanMapper planMapper,
         PlanCreationMapper planCreationMapper,
         PlanResponseMapper planResponseMapper,
-        UpdatePlanRequestProcessor updatePlanRequestProcessor, ProjectService projectService)
+        UpdatePlanRequestProcessor updatePlanRequestProcessor,
+        ProjectService projectService)
     {
         this.historyMapper = historyMapper;
         this.planService = planService;
-        this.planMapper = planMapper;
         this.planCreationMapper = planCreationMapper;
         this.planResponseMapper = planResponseMapper;
         this.updatePlanRequestProcessor = updatePlanRequestProcessor;
@@ -175,9 +172,9 @@ public class PlanController
     }
 
     @PutMapping(value = {"/{pin}"})
-    public HistoryDTO updatePlan(@PathVariable String pin, @RequestBody PlanDTO planDTO)
+    public HistoryDTO updatePlan(@PathVariable String pin, @RequestBody PlanUpdateDTO planUpdateDTO)
     {
-        Plan plan = getPlanToUpdate(pin, planDTO);
+        Plan plan = getPlanToUpdate(pin, planUpdateDTO);
         History history = planService.updatePlan(pin, plan);
         HistoryDTO historyDTO = new HistoryDTO();
         if (history != null)
@@ -187,11 +184,11 @@ public class PlanController
         return historyDTO;
     }
 
-    private Plan getPlanToUpdate(String pin, PlanDTO planDTO)
+    private Plan getPlanToUpdate(String pin, PlanUpdateDTO planUpdateDTO)
     {
         Plan currentPlan = getNotNullPlanByPin(pin);
         Plan newPlan = new Plan(currentPlan);
-        return updatePlanRequestProcessor.getPlanToUpdate(newPlan, planDTO);
+        return updatePlanRequestProcessor.getPlanToUpdate(newPlan, planUpdateDTO);
     }
 
     private ChangeResponse buildChangeResponse(Plan plan)

--- a/impc_prod_tracker/rest-api/src/main/java/org/gentar/biology/plan/mappers/PlanBasicDataMapper.java
+++ b/impc_prod_tracker/rest-api/src/main/java/org/gentar/biology/plan/mappers/PlanBasicDataMapper.java
@@ -17,7 +17,6 @@ import org.gentar.biology.plan.attempt.phenotyping.PhenotypingAttemptMapper;
 import org.gentar.biology.plan.plan_starting_point.PlanStartingPointDTO;
 import org.gentar.biology.plan.starting_point.PlanStartingPoint;
 import org.gentar.biology.starting_point.PlanStartingPointMapper;
-import org.gentar.exceptions.UserOperationFailedException;
 import org.springframework.stereotype.Component;
 import java.util.HashSet;
 import java.util.List;
@@ -127,9 +126,12 @@ public class PlanBasicDataMapper implements Mapper<Plan, PlanBasicDataDTO>
             if (planBasicDataDTO!= null && planBasicDataDTO.getPlanCommonDataDTO() != null)
             {
                 plan = planCommonDataMapper.toEntity(planBasicDataDTO.getPlanCommonDataDTO());
+                // Set id to plan. If the object is new the id will be null.
+                plan.setId(planBasicDataDTO.getId());
+
+                setAttempt(plan, planBasicDataDTO);
             }
         }
-        setAttempt(plan, planBasicDataDTO);
         return plan;
     }
 
@@ -156,10 +158,6 @@ public class PlanBasicDataMapper implements Mapper<Plan, PlanBasicDataDTO>
         {
             CrisprAttempt crisprAttempt =
                 crisprAttemptMapper.toEntity(planBasicDataDTO.getCrisprAttemptDTO());
-            if (plan.getCrisprAttempt().getImitsMiAttempt() != null)
-            {
-                crisprAttempt.setImitsMiAttempt(plan.getCrisprAttempt().getImitsMiAttempt());
-            }
             crisprAttempt.setPlan(plan);
             crisprAttempt.setId(plan.getId());
             plan.setCrisprAttempt(crisprAttempt);

--- a/impc_prod_tracker/rest-api/src/main/java/org/gentar/biology/plan/mappers/PlanCommonDataMapper.java
+++ b/impc_prod_tracker/rest-api/src/main/java/org/gentar/biology/plan/mappers/PlanCommonDataMapper.java
@@ -1,6 +1,5 @@
 package org.gentar.biology.plan.mappers;
 
-import org.gentar.EntityMapper;
 import org.gentar.Mapper;
 import org.gentar.biology.plan.Plan;
 import org.gentar.biology.plan.PlanCommonDataDTO;
@@ -15,18 +14,15 @@ import java.util.Set;
 @Component
 public class PlanCommonDataMapper implements Mapper<Plan, PlanCommonDataDTO>
 {
-    private EntityMapper entityMapper;
     private FunderMapper funderMapper;
     private WorkUnitMapper workUnitMapper;
     private WorkGroupMapper workGroupMapper;
 
     public PlanCommonDataMapper(
-        EntityMapper entityMapper,
         FunderMapper funderMapper,
         WorkUnitMapper workUnitMapper,
         WorkGroupMapper workGroupMapper)
     {
-        this.entityMapper = entityMapper;
         this.funderMapper = funderMapper;
         this.workUnitMapper = workUnitMapper;
         this.workGroupMapper = workGroupMapper;
@@ -59,7 +55,10 @@ public class PlanCommonDataMapper implements Mapper<Plan, PlanCommonDataDTO>
     @Override
     public Plan toEntity(PlanCommonDataDTO planCommonDataDTO)
     {
-        Plan plan = entityMapper.toTarget(planCommonDataDTO, Plan.class);
+        Plan plan = new Plan();
+        plan.setComment(planCommonDataDTO.getComment());
+        plan.setProductsAvailableForGeneralPublic(
+            planCommonDataDTO.getProductsAvailableForGeneralPublic());
         Set<Funder> funders =
             new HashSet<>(funderMapper.toEntities(planCommonDataDTO.getFunderNames()));
         plan.setFunders(funders);

--- a/impc_prod_tracker/rest-api/src/main/java/org/gentar/biology/plan/mappers/PlanCreationMapper.java
+++ b/impc_prod_tracker/rest-api/src/main/java/org/gentar/biology/plan/mappers/PlanCreationMapper.java
@@ -1,6 +1,5 @@
 package org.gentar.biology.plan.mappers;
 
-import org.gentar.EntityMapper;
 import org.gentar.Mapper;
 import org.gentar.biology.plan.Plan;
 import org.gentar.biology.plan.PlanBasicDataDTO;
@@ -11,18 +10,15 @@ import org.springframework.stereotype.Component;
 @Component
 public class PlanCreationMapper implements Mapper<Plan, PlanCreationDTO>
 {
-    private EntityMapper entity;
     private PlanBasicDataMapper planBasicDataMapper;
     private PlanTypeMapper planTypeMapper;
     private AttemptTypeMapper attemptTypeMapper;
 
     public PlanCreationMapper(
-        EntityMapper entity,
         PlanBasicDataMapper planBasicDataMapper,
         PlanTypeMapper planTypeMapper,
         AttemptTypeMapper attemptTypeMapper)
     {
-        this.entity = entity;
         this.planBasicDataMapper = planBasicDataMapper;
         this.planTypeMapper = planTypeMapper;
         this.attemptTypeMapper = attemptTypeMapper;
@@ -32,7 +28,8 @@ public class PlanCreationMapper implements Mapper<Plan, PlanCreationDTO>
     public PlanCreationDTO toDto(Plan plan)
     {
         PlanBasicDataDTO planBasicDataDTO = planBasicDataMapper.toDto(plan);
-        PlanCreationDTO planCreationDTO = entity.toTarget(planBasicDataDTO, PlanCreationDTO.class);
+        PlanCreationDTO planCreationDTO = new PlanCreationDTO();
+        planCreationDTO.setPlanBasicDataDTO(planBasicDataDTO);
         if (plan.getProject() != null)
         {
             planCreationDTO.setTpn(plan.getProject().getTpn());

--- a/impc_prod_tracker/rest-api/src/main/java/org/gentar/biology/plan/mappers/PlanUpdateMapper.java
+++ b/impc_prod_tracker/rest-api/src/main/java/org/gentar/biology/plan/mappers/PlanUpdateMapper.java
@@ -3,21 +3,17 @@ package org.gentar.biology.plan.mappers;
 import org.gentar.Mapper;
 import org.gentar.biology.plan.Plan;
 import org.gentar.biology.plan.PlanBasicDataDTO;
-import org.gentar.biology.plan.PlanService;
 import org.gentar.biology.plan.PlanUpdateDTO;
-import org.gentar.statemachine.ProcessEvent;
 import org.springframework.stereotype.Component;
 
 @Component
 public class PlanUpdateMapper implements Mapper<Plan, PlanUpdateDTO>
 {
     private PlanBasicDataMapper planBasicDataMapper;
-    private PlanService planService;
 
-    public PlanUpdateMapper(PlanBasicDataMapper planBasicDataMapper, PlanService planService)
+    public PlanUpdateMapper(PlanBasicDataMapper planBasicDataMapper)
     {
         this.planBasicDataMapper = planBasicDataMapper;
-        this.planService = planService;
     }
 
     @Override
@@ -37,15 +33,14 @@ public class PlanUpdateMapper implements Mapper<Plan, PlanUpdateDTO>
     @Override
     public Plan toEntity(PlanUpdateDTO planUpdateDTO)
     {
-        Plan plan = planBasicDataMapper.toEntity(planUpdateDTO.getPlanBasicDataDTO());
-        setEvent(plan, planUpdateDTO);
+        Plan plan = new Plan();
+        PlanBasicDataDTO planBasicDataDTO = planUpdateDTO.getPlanBasicDataDTO();
+        if (planBasicDataDTO != null)
+        {
+            planBasicDataDTO.setId(planUpdateDTO.getId());
+            plan = planBasicDataMapper.toEntity(planBasicDataDTO);
+        }
+        plan.setId(planUpdateDTO.getId());
         return plan;
-    }
-
-    private void setEvent(Plan plan, PlanUpdateDTO planUpdateDTO)
-    {
-        String action = planUpdateDTO.getStatusTransitionDTO().getActionToExecute();
-        ProcessEvent processEvent = planService.getProcessEventByName(plan, action);
-        plan.setEvent(processEvent);
     }
 }

--- a/impc_prod_tracker/rest-api/src/test/java/org/gentar/biology/plan/mappers/PlanCommonDataMapperTest.java
+++ b/impc_prod_tracker/rest-api/src/test/java/org/gentar/biology/plan/mappers/PlanCommonDataMapperTest.java
@@ -1,6 +1,5 @@
 package org.gentar.biology.plan.mappers;
 
-import org.gentar.EntityMapper;
 import org.gentar.biology.plan.Plan;
 import org.gentar.biology.plan.PlanCommonDataDTO;
 import org.gentar.biology.plan.attempt.AttemptType;
@@ -18,7 +17,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import java.util.HashSet;
 import java.util.Set;
@@ -40,8 +38,6 @@ class PlanCommonDataMapperTest
     public static final boolean PRODUCTS_AVAILABLE_FOR_GENERAL_PUBLIC = true;
     private PlanCommonDataMapper testInstance;
 
-    @Autowired
-    private EntityMapper entityMapper;
     @Mock
     private FunderMapper funderMapper;
     @Mock
@@ -53,7 +49,7 @@ class PlanCommonDataMapperTest
     void setUp()
     {
         testInstance =
-            new PlanCommonDataMapper(entityMapper, funderMapper, workUnitMapper, workGroupMapper);
+            new PlanCommonDataMapper(funderMapper, workUnitMapper, workGroupMapper);
     }
 
     @Test

--- a/impc_prod_tracker/rest-api/src/test/java/org/gentar/biology/plan/mappers/PlanCreationMapperTest.java
+++ b/impc_prod_tracker/rest-api/src/test/java/org/gentar/biology/plan/mappers/PlanCreationMapperTest.java
@@ -1,6 +1,5 @@
 package org.gentar.biology.plan.mappers;
 
-import org.gentar.EntityMapper;
 import org.gentar.biology.plan.Plan;
 import org.gentar.biology.plan.PlanBasicDataDTO;
 import org.gentar.biology.plan.PlanCommonDataDTO;
@@ -15,7 +14,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import static org.mockito.Mockito.times;
@@ -28,8 +26,6 @@ class PlanCreationMapperTest
 {
     private PlanCreationMapper testInstance;
 
-    @Autowired
-    private EntityMapper entityMapper;
     @Mock
     private PlanBasicDataMapper planBasicDataMapper;
     @Mock
@@ -41,7 +37,7 @@ class PlanCreationMapperTest
     public void setup()
     {
         testInstance =
-            new PlanCreationMapper(entityMapper, planBasicDataMapper, planTypeMapper, attemptTypeMapper);
+            new PlanCreationMapper(planBasicDataMapper, planTypeMapper, attemptTypeMapper);
     }
 
     @Test

--- a/impc_prod_tracker/rest-api/src/test/java/org/gentar/biology/plan/mappers/PlanUpdateMapperTest.java
+++ b/impc_prod_tracker/rest-api/src/test/java/org/gentar/biology/plan/mappers/PlanUpdateMapperTest.java
@@ -1,23 +1,20 @@
 package org.gentar.biology.plan.mappers;
 
-import org.gentar.EntityMapper;
 import org.gentar.biology.plan.Plan;
-import org.gentar.biology.plan.PlanService;
+import org.gentar.biology.plan.PlanBasicDataDTO;
 import org.gentar.biology.plan.PlanUpdateDTO;
-import org.gentar.common.state_machine.StatusTransitionDTO;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.boot.test.context.SpringBootTest;
 
-import static org.mockito.ArgumentMatchers.any;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@SpringBootTest
 @ExtendWith(MockitoExtension.class)
 class PlanUpdateMapperTest
 {
@@ -26,13 +23,10 @@ class PlanUpdateMapperTest
     @Mock
     private PlanBasicDataMapper planBasicDataMapper;
 
-    @Mock
-    private PlanService planService;
-
     @BeforeEach
     void setUp()
     {
-        testInstance = new PlanUpdateMapper(planBasicDataMapper, planService);
+        testInstance = new PlanUpdateMapper(planBasicDataMapper);
     }
 
     @Test
@@ -48,14 +42,14 @@ class PlanUpdateMapperTest
     void toEntity()
     {
         PlanUpdateDTO planUpdateDTO = new PlanUpdateDTO();
-        StatusTransitionDTO statusTransitionDTO = new StatusTransitionDTO();
-        statusTransitionDTO.setActionToExecute("abandonWhenCreated");
-        planUpdateDTO.setStatusTransitionDTO(statusTransitionDTO);
-        Plan plan = new Plan();
-        when(planBasicDataMapper.toEntity(any())).thenReturn(plan);
+        planUpdateDTO.setId(1L);
+        PlanBasicDataDTO planBasicDataDTO = new PlanBasicDataDTO();
+        planUpdateDTO.setPlanBasicDataDTO(planBasicDataDTO);
+        when(planBasicDataMapper.toEntity(planBasicDataDTO)).thenReturn(new Plan());
 
-        testInstance.toEntity(planUpdateDTO);
+        Plan plan = testInstance.toEntity(planUpdateDTO);
 
-        verify(planService, times(1)).getProcessEventByName(plan, "abandonWhenCreated");
+        verify(planBasicDataMapper, times(1)).toEntity(planUpdateDTO.getPlanBasicDataDTO());
+        assertThat(plan.getId(), is(planUpdateDTO.getId()));
     }
 }

--- a/impc_prod_tracker/rest-api/src/test/java/org/gentar/web/controller/project/ProjectControllerTest.java
+++ b/impc_prod_tracker/rest-api/src/test/java/org/gentar/web/controller/project/ProjectControllerTest.java
@@ -208,6 +208,7 @@ class ProjectControllerTest extends ControllerTestTemplate
         projectCommonDataDTO.setComment("A new comment");
         projectCommonDataDTO.setProjectExternalRef("new external reference");
         projectCommonDataDTO.setRecovery(true);
+        projectUpdateDTO.setTpn("TPN:01");
         projectUpdateDTO.setProjectCommonDataDTO(projectCommonDataDTO);
 
         ResultActions resultActions = mvc().perform(MockMvcRequestBuilders


### PR DESCRIPTION
- Fix planStatusStamps and outcomes being null when updating a plan.
- Fix error when deleting the event triggered by user if there was an event triggered by system as well.
- Set internal ids to PlanBasicDataDTO and PlanUpdateDTO to map correctly the attempts.
- Removing entityMappers when not needed.
- Moved setEvent call from planUpdateMapper to UpdatePlanRequestProcessor.