### PR TITLE
Fix error when creating colony without associating the distribution product

### DIFF
--- a/impc_prod_tracker/rest-api/src/main/java/org/gentar/biology/colony/ColonyMapper.java
+++ b/impc_prod_tracker/rest-api/src/main/java/org/gentar/biology/colony/ColonyMapper.java
@@ -85,6 +85,7 @@ public class ColonyMapper implements Mapper<Colony, ColonyDTO>
             Set<DistributionProduct> distributionProducts =
                 new HashSet<>(
                     distributionProductMapper.toEntities(colonyDTO.getDistributionProductDTOS()));
+            distributionProducts.forEach(x -> x.setColony(colony));
             colony.setDistributionProducts(distributionProducts);
         }
     }


### PR DESCRIPTION
Fix error when creating colony without associating the distribution product.