### PR TITLE
Improve changes detection mechanism for collections

### DIFF
--- a/impc_prod_tracker/core/src/main/java/org/gentar/audit/diff/ObjectInspector.java
+++ b/impc_prod_tracker/core/src/main/java/org/gentar/audit/diff/ObjectInspector.java
@@ -1,7 +1,5 @@
 package org.gentar.audit.diff;
 
-import org.gentar.util.CollectionPrinter;
-
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -61,7 +59,6 @@ class ObjectInspector
                 map.put(propertyWithValue.getPropertyDefinition().getName(), propertyWithValue);
                 if (mustCheckInternalProperties(propertyWithValue, parentData))
                 {
-                   // PropertyDefinition currentParent = getCurrentParent(parentData);
                     Class<?> parentTypeToRegister = getParentTypeToRegister(parentData);
 
                     checkedClassesTree.addRelationIfNotExist(
@@ -96,36 +93,6 @@ class ObjectInspector
             }
         }
         return parentTypeToRegister;
-        /*if (parentData != null)
-        {
-            // If the current element is the child of a collection, we don't want to register in the
-            // dependencies tree the relation children->Collection but children->Owner of the collection
-            if (PropertyChecker.isCollection(parentData.getType()))
-            {
-                parentTypeToRegister = parentData.getParentType();
-            }
-            else
-            {
-                parentTypeToRegister = parentData.getType();
-            }
-        }
-        return parentTypeToRegister;
-        /*
-        PropertyDefinition propertyDefinition = parentData;
-        if (parentData == null)
-        {
-            propertyDefinition = new PropertyDefinition(null, object.getClass(), null);
-        }
-        else
-        {
-            // If the current element is the child of a collection, we don't want to register in the
-            // dependencies tree the relation children->Collection but children->Owner of the collection
-            if (PropertyChecker.isCollection(parentData.getType()))
-            {
-                propertyDefinition.setType(parentData.getParentType());
-            }
-        }
-        return propertyDefinition;*/
     }
 
     public Map<String, PropertyDescription> getMap()

--- a/impc_prod_tracker/core/src/main/java/org/gentar/biology/location/Location.java
+++ b/impc_prod_tracker/core/src/main/java/org/gentar/biology/location/Location.java
@@ -2,6 +2,7 @@ package org.gentar.biology.location;
 
 import lombok.*;
 import org.gentar.BaseEntity;
+import org.gentar.audit.diff.IgnoreForAuditingChanges;
 import org.gentar.biology.sequence_location.SequenceLocation;
 import org.gentar.biology.species.Species;
 import org.gentar.biology.strain.Strain;
@@ -42,6 +43,7 @@ public class Location extends BaseEntity
 
     @EqualsAndHashCode.Exclude
     @ToString.Exclude
+    @IgnoreForAuditingChanges
     @OneToMany(cascade=CascadeType.ALL, fetch=FetchType.EAGER)
     @JoinColumn(name = "location_id")
     private List<SequenceLocation> sequenceLocations;

--- a/impc_prod_tracker/core/src/main/java/org/gentar/biology/location/LocationRepository.java
+++ b/impc_prod_tracker/core/src/main/java/org/gentar/biology/location/LocationRepository.java
@@ -4,4 +4,5 @@ import org.springframework.data.repository.CrudRepository;
 
 public interface LocationRepository extends CrudRepository<Location, Long>
 {
+    Location findFirstById(Long id);
 }

--- a/impc_prod_tracker/core/src/main/java/org/gentar/biology/location/LocationService.java
+++ b/impc_prod_tracker/core/src/main/java/org/gentar/biology/location/LocationService.java
@@ -1,0 +1,32 @@
+package org.gentar.biology.location;
+
+import org.gentar.exceptions.UserOperationFailedException;
+import org.springframework.stereotype.Component;
+
+@Component
+public class LocationService
+{
+    private static final String ERROR = "Location with id [%s] does not exist.";
+
+    private LocationRepository locationRepository;
+
+    public LocationService(LocationRepository locationRepository)
+    {
+        this.locationRepository = locationRepository;
+    }
+
+    public Location getById(Long id)
+    {
+        return locationRepository.findFirstById(id);
+    }
+
+    public Location getByIdFailsIfNull(Long id)
+    {
+        Location location = getById(id);
+        if (location == null)
+        {
+            throw new UserOperationFailedException(String.format(ERROR, id));
+        }
+        return location;
+    }
+}

--- a/impc_prod_tracker/core/src/main/java/org/gentar/biology/mutation/Mutation.java
+++ b/impc_prod_tracker/core/src/main/java/org/gentar/biology/mutation/Mutation.java
@@ -17,6 +17,7 @@ package org.gentar.biology.mutation;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.*;
+import org.gentar.audit.diff.IgnoreForAuditingChanges;
 import org.gentar.biology.mutation.categorizarion.MutationCategorization;
 import org.gentar.biology.mutation.genetic_type.GeneticMutationType;
 import org.gentar.biology.mutation.qc_results.MutationQcResult;
@@ -107,7 +108,7 @@ public class Mutation extends BaseEntity
     private Set<Gene> genes;
 
     @ToString.Exclude
-    @JsonIgnore
+    @IgnoreForAuditingChanges
     @ManyToMany
     @JoinTable(
             name = "mutation_outcome",

--- a/impc_prod_tracker/core/src/main/java/org/gentar/biology/mutation/MutationRepository.java
+++ b/impc_prod_tracker/core/src/main/java/org/gentar/biology/mutation/MutationRepository.java
@@ -23,5 +23,7 @@ public interface MutationRepository extends CrudRepository<Mutation, Long>
     @Query("SELECT max(m.min) FROM Mutation m")
     String getMaxMin();
 
+    Mutation findFirstById(Long id);
+
     Mutation findByMin(String min);
 }

--- a/impc_prod_tracker/core/src/main/java/org/gentar/biology/mutation/MutationService.java
+++ b/impc_prod_tracker/core/src/main/java/org/gentar/biology/mutation/MutationService.java
@@ -4,9 +4,9 @@ import org.gentar.audit.history.History;
 
 public interface MutationService
 {
+    Mutation getById(Long id);
+    Mutation getByIdFailsIfNull(Long id);
     Mutation getMutationByMinFailsIfNull(String min);
-
     Mutation create(Mutation mutation);
-
     History update(Mutation mutation);
 }

--- a/impc_prod_tracker/core/src/main/java/org/gentar/biology/mutation/MutationServiceImpl.java
+++ b/impc_prod_tracker/core/src/main/java/org/gentar/biology/mutation/MutationServiceImpl.java
@@ -18,6 +18,7 @@ public class MutationServiceImpl implements MutationService
     private MutationUpdater mutationUpdater;
 
     private static final String MUTATION_NOT_EXIST_ERROR = "Mutation %s does not exist.";
+    private static final String MUTATION_BY_ID_NOT_EXIST_ERROR = "Mutation with id [%s] does not exist.";
 
     public MutationServiceImpl(
         MutationRepository mutationRepository,
@@ -29,6 +30,23 @@ public class MutationServiceImpl implements MutationService
         this.sequenceService = sequenceService;
         this.mutationSequenceService = mutationSequenceService;
         this.mutationUpdater = mutationUpdater;
+    }
+
+    @Override
+    public Mutation getById(Long id)
+    {
+        return mutationRepository.findFirstById(id);
+    }
+
+    @Override
+    public Mutation getByIdFailsIfNull(Long id)
+    {
+        Mutation mutation = getById(id);
+        if (mutation == null)
+        {
+            throw new UserOperationFailedException(String.format(MUTATION_BY_ID_NOT_EXIST_ERROR, id));
+        }
+        return mutation;
     }
 
     @Override

--- a/impc_prod_tracker/core/src/main/java/org/gentar/biology/mutation/MutationUpdater.java
+++ b/impc_prod_tracker/core/src/main/java/org/gentar/biology/mutation/MutationUpdater.java
@@ -2,10 +2,12 @@ package org.gentar.biology.mutation;
 
 import org.gentar.audit.history.History;
 import org.gentar.audit.history.HistoryService;
+import org.gentar.biology.colony.Colony_;
 import org.gentar.biology.location.Location;
 import org.gentar.biology.mutation.sequence.MutationSequence;
 import org.gentar.biology.sequence.Sequence;
 import org.gentar.biology.sequence_location.SequenceLocation;
+import org.gentar.biology.status.Status_;
 import org.springframework.stereotype.Component;
 
 import java.util.Collection;
@@ -56,55 +58,14 @@ public class MutationUpdater
 
     private History detectTrackOfChanges(Mutation originalMutation, Mutation newMutation)
     {
-        testChangeLoc(originalMutation, newMutation);
         History history =
             historyService.detectTrackOfChanges(
                 originalMutation, newMutation, originalMutation.getId());
-        //history = historyService.filterDetailsInNestedEntity(history, Colony_.STATUS, Status_.NAME);
+        if (history != null)
+        {
+            history = historyService.filterDetailsInNestedEntity(history, Colony_.STATUS, Status_.NAME);
+        }
         return history;
     }
 
-    private void testChangeLoc(Mutation originalMutation, Mutation newMutation)
-    {
-        MutationSequence originalMutationSequence = null;
-        MutationSequence newMutationSequence = null;
-        Location originalLocation = null;
-        Location newLocation = null;
-        // Original
-        for (MutationSequence mutationSequence : originalMutation.getMutationSequences())
-        {
-            originalMutationSequence = mutationSequence;
-        }
-
-        for (SequenceLocation sequenceLocation : originalMutationSequence.getSequence().getSequenceLocations())
-        {
-            Location location = sequenceLocation.getLocation();
-            originalLocation = location;
-        }
-        // New
-        for (MutationSequence mutationSequence : newMutation.getMutationSequences())
-        {
-            newMutationSequence = mutationSequence;
-        }
-
-        for (SequenceLocation sequenceLocation : newMutationSequence.getSequence().getSequenceLocations())
-        {
-            Location location = sequenceLocation.getLocation();
-            newLocation = location;
-        }
-        //boolean test = originalLocation.equals(newLocation);
-    }
-
-    private Location getLocationById(Collection<SequenceLocation> sequenceLocations, Long id)
-    {
-        for (SequenceLocation sequenceLocation: sequenceLocations)
-        {
-            Location location = sequenceLocation.getLocation();
-            if (location.getId().equals(id))
-            {
-                return location;
-            }
-        }
-        return null;
-    }
 }

--- a/impc_prod_tracker/core/src/main/java/org/gentar/biology/mutation/sequence/MutationSequenceRepository.java
+++ b/impc_prod_tracker/core/src/main/java/org/gentar/biology/mutation/sequence/MutationSequenceRepository.java
@@ -2,5 +2,7 @@ package org.gentar.biology.mutation.sequence;
 
 import org.springframework.data.repository.CrudRepository;
 
-public interface MutationSequenceRepository extends CrudRepository<MutationSequence, Long> {
+public interface MutationSequenceRepository extends CrudRepository<MutationSequence, Long>
+{
+    MutationSequence findFirstById(Long id);
 }

--- a/impc_prod_tracker/core/src/main/java/org/gentar/biology/mutation/sequence/MutationSequenceService.java
+++ b/impc_prod_tracker/core/src/main/java/org/gentar/biology/mutation/sequence/MutationSequenceService.java
@@ -1,11 +1,29 @@
 package org.gentar.biology.mutation.sequence;
 
+import org.gentar.exceptions.UserOperationFailedException;
 import org.springframework.stereotype.Component;
 
 @Component
 public class MutationSequenceService
 {
     private MutationSequenceRepository mutationSequenceRepository;
+
+    private static final String NOT_FOUND_ERROR = "Mutation sequence with id [%s] does not exist.";
+
+    public MutationSequence getById(Long id)
+    {
+        return mutationSequenceRepository.findFirstById(id);
+    }
+
+    public MutationSequence getByIdFailsIfNull(Long id)
+    {
+        MutationSequence mutationSequence = getById(id);
+        if (mutationSequence == null)
+        {
+            throw new UserOperationFailedException(String.format(NOT_FOUND_ERROR, id));
+        }
+        return mutationSequence;
+    }
 
     public MutationSequenceService(MutationSequenceRepository mutationSequenceRepository)
     {

--- a/impc_prod_tracker/core/src/main/java/org/gentar/biology/outcome/Outcome.java
+++ b/impc_prod_tracker/core/src/main/java/org/gentar/biology/outcome/Outcome.java
@@ -3,6 +3,7 @@ package org.gentar.biology.outcome;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.*;
 import org.gentar.BaseEntity;
+import org.gentar.audit.diff.IgnoreForAuditingChanges;
 import org.gentar.biology.colony.Colony;
 import org.gentar.biology.mutation.Mutation;
 import org.gentar.biology.outcome.type.OutcomeType;
@@ -32,6 +33,7 @@ public class Outcome extends BaseEntity implements Resource<Outcome>
     @ManyToOne
     private OutcomeType outcomeType;
 
+    @IgnoreForAuditingChanges
     @ManyToOne
     private Plan plan;
 
@@ -52,6 +54,7 @@ public class Outcome extends BaseEntity implements Resource<Outcome>
 
     @ToString.Exclude
     @EqualsAndHashCode.Exclude
+    @IgnoreForAuditingChanges
     @OneToMany(cascade = CascadeType.ALL, mappedBy = "outcome")
     private Set<PlanStartingPoint> planStartingPoints;
 

--- a/impc_prod_tracker/core/src/main/java/org/gentar/biology/sequence/Sequence.java
+++ b/impc_prod_tracker/core/src/main/java/org/gentar/biology/sequence/Sequence.java
@@ -33,7 +33,7 @@ public class Sequence extends BaseEntity
 
     @EqualsAndHashCode.Exclude
     @ToString.Exclude
-    @OneToMany(cascade=CascadeType.ALL, fetch=FetchType.EAGER, orphanRemoval=true)
+    @OneToMany(cascade=CascadeType.ALL)
     @JoinColumn(name = "sequence_id")
     private List<SequenceLocation> sequenceLocations;
 

--- a/impc_prod_tracker/core/src/main/java/org/gentar/biology/sequence/SequenceRepository.java
+++ b/impc_prod_tracker/core/src/main/java/org/gentar/biology/sequence/SequenceRepository.java
@@ -2,5 +2,7 @@ package org.gentar.biology.sequence;
 
 import org.springframework.data.repository.CrudRepository;
 
-public interface SequenceRepository extends CrudRepository<Sequence, Long> {
+public interface SequenceRepository extends CrudRepository<Sequence, Long>
+{
+    Sequence findFirstById(Long id);
 }

--- a/impc_prod_tracker/core/src/main/java/org/gentar/biology/sequence/SequenceService.java
+++ b/impc_prod_tracker/core/src/main/java/org/gentar/biology/sequence/SequenceService.java
@@ -2,6 +2,7 @@ package org.gentar.biology.sequence;
 
 import org.gentar.biology.sequence.category.SequenceCategory;
 import org.gentar.biology.sequence.category.SequenceCategoryName;
+import org.gentar.exceptions.UserOperationFailedException;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -9,9 +10,26 @@ public class SequenceService
 {
     private SequenceRepository sequenceRepository;
 
+    private static final String NOT_FOUND_ERROR = "The sequence with if [%s] does not exist.";
+
     public SequenceService(SequenceRepository sequenceRepository)
     {
         this.sequenceRepository = sequenceRepository;
+    }
+
+    public Sequence getById(Long id)
+    {
+        return sequenceRepository.findFirstById(id);
+    }
+
+    public Sequence getByIdFailsIfNull(Long id)
+    {
+        Sequence sequence = getById(id);
+        if (sequence == null)
+        {
+            throw new UserOperationFailedException(String.format(NOT_FOUND_ERROR, id));
+        }
+        return sequence;
     }
 
     /**

--- a/impc_prod_tracker/core/src/main/java/org/gentar/biology/sequence_location/SequenceLocation.java
+++ b/impc_prod_tracker/core/src/main/java/org/gentar/biology/sequence_location/SequenceLocation.java
@@ -35,6 +35,9 @@ public class SequenceLocation extends BaseEntity implements Serializable {
         this.id = sequenceLocation.getId();
         this.sequence = sequenceLocation.getSequence();
         this.index = sequenceLocation.getIndex();
-        this.location = new Location(sequenceLocation.getLocation());
+        if (sequenceLocation.getLocation() != null)
+        {
+            this.location = new Location(sequenceLocation.getLocation());
+        }
     }
 }

--- a/impc_prod_tracker/core/src/main/java/org/gentar/biology/sequence_location/SequenceLocationRepository.java
+++ b/impc_prod_tracker/core/src/main/java/org/gentar/biology/sequence_location/SequenceLocationRepository.java
@@ -5,6 +5,8 @@ import org.gentar.biology.sequence.Sequence;
 
 import java.util.List;
 
-public interface SequenceLocationRepository extends CrudRepository<SequenceLocation, Long> {
+public interface SequenceLocationRepository extends CrudRepository<SequenceLocation, Long>
+{
+    SequenceLocation findFirstById(Long id);
     List<SequenceLocation> findAllBySequence(Sequence sequence);
 }

--- a/impc_prod_tracker/core/src/main/java/org/gentar/biology/sequence_location/SequenceLocationService.java
+++ b/impc_prod_tracker/core/src/main/java/org/gentar/biology/sequence_location/SequenceLocationService.java
@@ -1,0 +1,32 @@
+package org.gentar.biology.sequence_location;
+
+import org.gentar.exceptions.UserOperationFailedException;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SequenceLocationService
+{
+    private final SequenceLocationRepository sequenceLocationRepository;
+
+    private static final String NOT_FOUND_ERROR = "Sequence location with id [%s] does not exist.";
+
+    public SequenceLocationService(SequenceLocationRepository sequenceLocationRepository)
+    {
+        this.sequenceLocationRepository = sequenceLocationRepository;
+    }
+
+    public SequenceLocation getById(Long id)
+    {
+        return sequenceLocationRepository.findFirstById(id);
+    }
+
+    public SequenceLocation getByIdFailsIfNull(Long id)
+    {
+        SequenceLocation sequenceLocation = getById(id);
+        if (sequenceLocation == null)
+        {
+            throw new UserOperationFailedException(String.format(NOT_FOUND_ERROR, id));
+        }
+        return sequenceLocation;
+    }
+}

--- a/impc_prod_tracker/core/src/test/java/org/gentar/audit/history/HistoryChangesAdaptorTest.java
+++ b/impc_prod_tracker/core/src/test/java/org/gentar/audit/history/HistoryChangesAdaptorTest.java
@@ -1,13 +1,12 @@
 package org.gentar.audit.history;
 
 import org.gentar.audit.diff.ChangeType;
-import org.gentar.audit.history.detail.HistoryDetail;
+
 import org.gentar.biology.project.assignment.AssignmentStatus;
 import org.gentar.biology.plan.Plan;
 import org.gentar.biology.project.Project;
-import org.gentar.util.CollectionPrinter;
+import org.gentar.biology.species.Species;
 import org.junit.jupiter.api.Test;
-
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -21,6 +20,29 @@ import static org.hamcrest.Matchers.nullValue;
 public class HistoryChangesAdaptorTest
 {
     private HistoryChangesAdaptor<Project> testInstance;
+
+    @Test
+    public void testSmallClass()
+    {
+        Species species1 = new Species();
+        species1.setId(1L);
+        Project project1 = new Project();
+        project1.setId(1L);
+        project1.setSpecies(new HashSet<>(Arrays.asList(species1)));
+        species1.setProjects(new HashSet<>(Arrays.asList(project1)));
+
+        Species species2 = new Species();
+        species2.setId(2L);
+        Project project2 = new Project();
+        project2.setId(2L);
+        project2.setSpecies(new HashSet<>(Arrays.asList(species2)));
+        species2.setProjects(new HashSet<>(Arrays.asList(project2)));
+
+        HistoryChangesAdaptor<Project> historyChangesAdaptor =
+            new HistoryChangesAdaptor<>(Arrays.asList("id"), project1, project2);
+
+        List<ChangeDescription> changeDescriptionList = historyChangesAdaptor.getChanges();
+    }
 
     @Test
     public void test()

--- a/impc_prod_tracker/rest-api/src/main/java/org/gentar/biology/location/LocationMapper.java
+++ b/impc_prod_tracker/rest-api/src/main/java/org/gentar/biology/location/LocationMapper.java
@@ -1,6 +1,5 @@
 package org.gentar.biology.location;
 
-import org.gentar.EntityMapper;
 import org.gentar.Mapper;
 import org.gentar.biology.strain.StrainMapper;
 import org.gentar.biology.species.SpeciesMapper;
@@ -9,28 +8,53 @@ import org.springframework.stereotype.Component;
 @Component
 public class LocationMapper implements Mapper<Location, LocationDTO>
 {
-    private EntityMapper entityMapper;
-    private StrainMapper strainMapper;
-    private SpeciesMapper speciesMapper;
+    private final StrainMapper strainMapper;
+    private final SpeciesMapper speciesMapper;
 
-    public LocationMapper(
-        EntityMapper entityMapper, StrainMapper strainMapper, SpeciesMapper speciesMapper)
+    public LocationMapper(StrainMapper strainMapper, SpeciesMapper speciesMapper)
     {
-        this.entityMapper = entityMapper;
         this.strainMapper = strainMapper;
         this.speciesMapper = speciesMapper;
     }
 
     public LocationDTO toDto(Location location)
     {
-        return entityMapper.toTarget(location, LocationDTO.class);
+        LocationDTO locationDTO = new LocationDTO();
+        if (location != null)
+        {
+            locationDTO.setId(location.getId());
+            locationDTO.setChr(location.getChr());
+            locationDTO.setStart(location.getStart());
+            locationDTO.setStop(location.getStop());
+            locationDTO.setStrand(location.getStrand());
+            locationDTO.setGenomeBuild(location.getGenomeBuild());
+            if (location.getStrain() != null)
+            {
+                locationDTO.setStrainName(location.getStrain().getName());
+            }
+            if (location.getSpecies() != null)
+            {
+                locationDTO.setSpeciesName(location.getSpecies().getName());
+            }
+        }
+        return locationDTO;
     }
 
     public Location toEntity(LocationDTO locationDTO)
     {
-        Location location = entityMapper.toTarget(locationDTO, Location.class);
-        location.setStrain(strainMapper.toEntity(locationDTO.getStrainName()));
-        location.setSpecies(speciesMapper.toEntity(locationDTO.getSpeciesName()));
+        Location location = new Location();
+        if (locationDTO != null)
+        {
+            location.setId(locationDTO.getId());
+            location.setChr(locationDTO.getChr());
+            location.setStart(locationDTO.getStart());
+            location.setStop(locationDTO.getStop());
+            location.setStrand(locationDTO.getStrand());
+            location.setGenomeBuild(locationDTO.getGenomeBuild());
+            location.setStrain(strainMapper.toEntity(locationDTO.getStrainName()));
+            location.setSpecies(speciesMapper.toEntity(locationDTO.getSpeciesName()));
+        }
         return location;
     }
+
 }

--- a/impc_prod_tracker/rest-api/src/main/java/org/gentar/biology/mutation/MutationCommonMapper.java
+++ b/impc_prod_tracker/rest-api/src/main/java/org/gentar/biology/mutation/MutationCommonMapper.java
@@ -14,12 +14,12 @@ import java.util.Set;
 @Component
 public class MutationCommonMapper implements Mapper<Mutation, MutationCommonDTO>
 {
-    private EntityMapper entityMapper;
-    private MutationQCResultMapper mutationQCResultMapper;
-    private MutationCategorizationMapper mutationCategorizationMapper;
-    private MutationSequenceMapper mutationSequenceMapper;
-    private GeneticMutationTypeMapper geneticMutationTypeMapper;
-    private MolecularMutationTypeMapper molecularMutationTypeMapper;
+    private final EntityMapper entityMapper;
+    private final MutationQCResultMapper mutationQCResultMapper;
+    private final MutationCategorizationMapper mutationCategorizationMapper;
+    private final MutationSequenceMapper mutationSequenceMapper;
+    private final GeneticMutationTypeMapper geneticMutationTypeMapper;
+    private final MolecularMutationTypeMapper molecularMutationTypeMapper;
 
     public MutationCommonMapper(
         EntityMapper entityMapper,
@@ -54,16 +54,19 @@ public class MutationCommonMapper implements Mapper<Mutation, MutationCommonDTO>
     public Mutation toEntity(MutationCommonDTO mutationCommonDTO)
     {
         Mutation mutation = new Mutation();
-        mutation.setAlleleConfirmed(mutationCommonDTO.getAlleleConfirmed());
-        mutation.setMgiAlleleSymbolRequiresConstruction(
-            mutationCommonDTO.getMgiAlleleSymbolRequiresConstruction());
-        setGeneticMutationType(mutation, mutationCommonDTO);
-        setMolecularMutationType(mutation, mutationCommonDTO);
-        setMutationQcResults(mutation, mutationCommonDTO);
-        setMutationSequences(mutation, mutationCommonDTO);
-        mutation.setMutationCategorizations(
-            new HashSet<>(mutationCategorizationMapper.toEntities(
-                mutationCommonDTO.getMutationCategorizationDTOS())));
+        if (mutationCommonDTO != null)
+        {
+            mutation.setAlleleConfirmed(mutationCommonDTO.getAlleleConfirmed());
+            mutation.setMgiAlleleSymbolRequiresConstruction(
+                mutationCommonDTO.getMgiAlleleSymbolRequiresConstruction());
+            setGeneticMutationType(mutation, mutationCommonDTO);
+            setMolecularMutationType(mutation, mutationCommonDTO);
+            setMutationQcResults(mutation, mutationCommonDTO);
+            setMutationSequences(mutation, mutationCommonDTO);
+            mutation.setMutationCategorizations(
+                new HashSet<>(mutationCategorizationMapper.toEntities(
+                    mutationCommonDTO.getMutationCategorizationDTOS())));
+        }
         return mutation;
     }
 

--- a/impc_prod_tracker/rest-api/src/main/java/org/gentar/biology/mutation/MutationController.java
+++ b/impc_prod_tracker/rest-api/src/main/java/org/gentar/biology/mutation/MutationController.java
@@ -111,7 +111,7 @@ public class MutationController
     }
 
     private Mutation getMutationToUpdate(
-        String pin, String tpo,  String min, MutationUpdateDTO mutationUpdateDTO)
+        String pin, String tpo, String min, MutationUpdateDTO mutationUpdateDTO)
     {
         Mutation currentMutation = outcomeService.getMutationByPinTpoAndMin(pin, tpo, min);
         return mutationRequestProcessor.getMutationToUpdate(currentMutation, mutationUpdateDTO);

--- a/impc_prod_tracker/rest-api/src/main/java/org/gentar/biology/mutation/MutationSequenceMapper.java
+++ b/impc_prod_tracker/rest-api/src/main/java/org/gentar/biology/mutation/MutationSequenceMapper.java
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class MutationSequenceMapper implements Mapper<MutationSequence, MutationSequenceDTO>
 {
-    private SequenceMapper sequenceMapper;
+    private final SequenceMapper sequenceMapper;
 
     public MutationSequenceMapper(SequenceMapper sequenceMapper)
     {
@@ -29,13 +29,17 @@ public class MutationSequenceMapper implements Mapper<MutationSequence, Mutation
     public MutationSequence toEntity(MutationSequenceDTO mutationSequenceDTO)
     {
         MutationSequence mutationSequence = new MutationSequence();
-        mutationSequence.setId(mutationSequenceDTO.getId());
-        mutationSequence.setIndex(mutationSequenceDTO.getIndex());
-        if (mutationSequenceDTO.getSequenceDTO() != null)
+        if (mutationSequenceDTO != null)
         {
-            mutationSequence.setSequence(
-                sequenceMapper.toEntity(mutationSequenceDTO.getSequenceDTO()));
+            mutationSequence.setId(mutationSequenceDTO.getId());
+            mutationSequence.setIndex(mutationSequenceDTO.getIndex());
+            if (mutationSequenceDTO.getSequenceDTO() != null)
+            {
+                mutationSequence.setSequence(
+                    sequenceMapper.toEntity(mutationSequenceDTO.getSequenceDTO()));
+            }
         }
+
         return mutationSequence;
     }
 }

--- a/impc_prod_tracker/rest-api/src/main/java/org/gentar/biology/mutation/MutationUpdateMapper.java
+++ b/impc_prod_tracker/rest-api/src/main/java/org/gentar/biology/mutation/MutationUpdateMapper.java
@@ -12,8 +12,8 @@ import java.util.Set;
 @Component
 public class MutationUpdateMapper implements Mapper<Mutation, MutationUpdateDTO>
 {
-    private MutationCommonMapper mutationCommonMapper;
-    private GeneService geneService;
+    private final MutationCommonMapper mutationCommonMapper;
+    private final GeneService geneService;
 
     public MutationUpdateMapper(MutationCommonMapper mutationCommonMapper, GeneService geneService)
     {

--- a/impc_prod_tracker/rest-api/src/main/java/org/gentar/biology/sequence/SequenceLocationMapper.java
+++ b/impc_prod_tracker/rest-api/src/main/java/org/gentar/biology/sequence/SequenceLocationMapper.java
@@ -1,6 +1,5 @@
 package org.gentar.biology.sequence;
 
-import org.gentar.EntityMapper;
 import org.gentar.Mapper;
 import org.gentar.biology.location.Location;
 import org.gentar.biology.location.LocationMapper;
@@ -10,13 +9,11 @@ import org.gentar.biology.sequence_location.SequenceLocation;
 @Component
 public class SequenceLocationMapper implements Mapper<SequenceLocation, SequenceLocationDTO>
 {
-    private LocationMapper locationMapper;
-    private EntityMapper entityMapper;
+    private final LocationMapper locationMapper;
 
-    public SequenceLocationMapper(LocationMapper locationMapper, EntityMapper entityMapper)
+    public SequenceLocationMapper(LocationMapper locationMapper)
     {
         this.locationMapper = locationMapper;
-        this.entityMapper = entityMapper;
     }
 
     public SequenceLocationDTO toDto(SequenceLocation sequenceLocation)
@@ -30,11 +27,13 @@ public class SequenceLocationMapper implements Mapper<SequenceLocation, Sequence
 
     public SequenceLocation toEntity(SequenceLocationDTO sequenceLocationDTO)
     {
-        SequenceLocation sequenceLocation =
-            entityMapper.toTarget(sequenceLocationDTO, SequenceLocation.class);
-        sequenceLocation.setId(sequenceLocationDTO.getId());
-        sequenceLocation.setIndex(sequenceLocationDTO.getLocationIndex());
-        setLocations(sequenceLocation, sequenceLocationDTO);
+        SequenceLocation sequenceLocation = new SequenceLocation();
+        if (sequenceLocationDTO != null)
+        {
+            sequenceLocation.setId(sequenceLocationDTO.getId());
+            sequenceLocation.setIndex(sequenceLocationDTO.getLocationIndex());
+            setLocations(sequenceLocation, sequenceLocationDTO);
+        }
         return sequenceLocation;
     }
 

--- a/impc_prod_tracker/rest-api/src/main/java/org/gentar/biology/sequence/SequenceMapper.java
+++ b/impc_prod_tracker/rest-api/src/main/java/org/gentar/biology/sequence/SequenceMapper.java
@@ -3,17 +3,15 @@ package org.gentar.biology.sequence;
 import org.gentar.Mapper;
 import org.springframework.stereotype.Component;
 import org.gentar.biology.sequence_location.SequenceLocation;
-
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 
 @Component
 public class SequenceMapper implements Mapper<Sequence, SequenceDTO>
 {
-    private SequenceLocationMapper sequenceLocationMapper;
-    private SequenceCategoryMapper sequenceCategoryMapper;
-    private SequenceTypeMapper sequenceTypeMapper;
+    private final SequenceLocationMapper sequenceLocationMapper;
+    private final SequenceCategoryMapper sequenceCategoryMapper;
+    private final SequenceTypeMapper sequenceTypeMapper;
 
     public SequenceMapper(
         SequenceLocationMapper sequenceLocationMapper,
@@ -47,13 +45,16 @@ public class SequenceMapper implements Mapper<Sequence, SequenceDTO>
     public Sequence toEntity(SequenceDTO sequenceDTO)
     {
         Sequence sequence = new Sequence();
-        sequence.setId(sequenceDTO.getId());
-        sequence.setSequence(sequenceDTO.getSequence());
-        sequence.setSequenceCategory(
-            sequenceCategoryMapper.toEntity(sequenceDTO.getSequenceCategoryName()));
-        sequence.setSequenceType(
-            sequenceTypeMapper.toEntity(sequenceDTO.getSequenceTypeName()));
-        setSequenceLocations(sequence, sequenceDTO);
+        if (sequenceDTO != null)
+        {
+            sequence.setId(sequenceDTO.getId());
+            sequence.setSequence(sequenceDTO.getSequence());
+            sequence.setSequenceCategory(
+                sequenceCategoryMapper.toEntity(sequenceDTO.getSequenceCategoryName()));
+            sequence.setSequenceType(
+                sequenceTypeMapper.toEntity(sequenceDTO.getSequenceTypeName()));
+            setSequenceLocations(sequence, sequenceDTO);
+        }
         return sequence;
     }
 

--- a/impc_prod_tracker/rest-api/src/main/resources/application.properties
+++ b/impc_prod_tracker/rest-api/src/main/resources/application.properties
@@ -13,3 +13,6 @@ spring.data.rest.base-path=/tracking-api
 spring.profiles.active=@activatedProperties@
 
 logging.level.web=debug
+
+# This is needed to avoid "InvalidDataAccessApiUsageException: Multiple representations of the same entity"
+spring.jpa.properties.hibernate.event.merge.entity_copy_observer=log

--- a/impc_prod_tracker/rest-api/src/test/java/org/gentar/biology/location/LocationMapperTest.java
+++ b/impc_prod_tracker/rest-api/src/test/java/org/gentar/biology/location/LocationMapperTest.java
@@ -1,0 +1,102 @@
+package org.gentar.biology.location;
+
+import org.gentar.biology.species.Species;
+import org.gentar.biology.species.SpeciesMapper;
+import org.gentar.biology.strain.Strain;
+import org.gentar.biology.strain.StrainMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class LocationMapperTest
+{
+    public static final long ID = 1L;
+    public static final String CHR = "X";
+    public static final long START = 100L;
+    public static final long STOP = 200L;
+    public static final String STRAND = "Strand";
+    public static final String GENOME_BUILD = "GenomeBuild";
+    public static final String STRAIN = "Strain";
+    public static final String SPECIES = "Species";
+    private LocationMapper testInstance;
+
+    @Mock
+    private StrainMapper strainMapper;
+    @Mock
+    private SpeciesMapper speciesMapper;
+
+    @BeforeEach
+    void setUp()
+    {
+        testInstance = new LocationMapper(strainMapper, speciesMapper);
+    }
+
+    @Test
+    void toDto()
+    {
+        Location location = new Location();
+        location.setId(ID);
+        location.setChr(CHR);
+        location.setStart(START);
+        location.setStop(STOP);
+        location.setStrand(STRAND);
+        location.setGenomeBuild(GENOME_BUILD);
+        Strain strain = new Strain();
+        strain.setName(STRAIN);
+        location.setStrain(strain);
+        Species species = new Species();
+        species.setName(SPECIES);
+        location.setSpecies(species);
+
+        LocationDTO locationDTO = testInstance.toDto(location);
+
+        assertThat(locationDTO.getId(), is(ID));
+        assertThat(locationDTO.getChr(), is(CHR));
+        assertThat(locationDTO.getStart(), is(START));
+        assertThat(locationDTO.getStop(), is(STOP));
+        assertThat(locationDTO.getStrand(), is(STRAND));
+        assertThat(locationDTO.getGenomeBuild(), is(GENOME_BUILD));
+        assertThat(locationDTO.getStrainName(), is(STRAIN));
+        assertThat(locationDTO.getSpeciesName(), is(SPECIES));
+    }
+
+    @Test
+    void toEntity()
+    {
+        LocationDTO locationDTO = new LocationDTO();
+        locationDTO.setChr(CHR);
+        locationDTO.setStart(START);
+        locationDTO.setStop(STOP);
+        locationDTO.setStrand(STRAND);
+        locationDTO.setGenomeBuild(GENOME_BUILD);
+        locationDTO.setStrainName(STRAIN);
+        locationDTO.setSpeciesName(SPECIES);
+
+        Strain mockStrain = new Strain();
+        mockStrain.setName(STRAIN);
+        Species mockSpecies = new Species();
+        mockSpecies.setName(SPECIES);
+
+        when(strainMapper.toEntity(STRAIN)).thenReturn(mockStrain);
+        when(speciesMapper.toEntity(SPECIES)).thenReturn(mockSpecies);
+
+        Location location = testInstance.toEntity(locationDTO);
+
+        assertThat(location.getId(), is(nullValue()));
+        assertThat(location.getChr(), is(CHR));
+        assertThat(location.getStart(), is(START));
+        assertThat(location.getStop(), is(STOP));
+        assertThat(location.getStrand(), is(STRAND));
+        assertThat(location.getGenomeBuild(), is(GENOME_BUILD));
+        assertThat(location.getStrain().getName(), is(STRAIN));
+        assertThat(location.getSpecies().getName(), is(SPECIES));
+    }
+}

--- a/impc_prod_tracker/rest-api/src/test/java/org/gentar/biology/mutation/MutationCommonMapperTest.java
+++ b/impc_prod_tracker/rest-api/src/test/java/org/gentar/biology/mutation/MutationCommonMapperTest.java
@@ -2,7 +2,6 @@ package org.gentar.biology.mutation;
 
 import org.gentar.EntityMapper;
 import org.gentar.biology.gene.Gene;
-import org.gentar.biology.gene.GeneMapper;
 import org.gentar.biology.mutation.categorizarion.MutationCategorization;
 import org.gentar.biology.mutation.genbank_file.GenbankFile;
 import org.gentar.biology.mutation.genetic_type.GeneticMutationType;

--- a/impc_prod_tracker/rest-api/src/test/java/org/gentar/biology/mutation/MutationSequenceMapperTest.java
+++ b/impc_prod_tracker/rest-api/src/test/java/org/gentar/biology/mutation/MutationSequenceMapperTest.java
@@ -12,13 +12,14 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 class MutationSequenceMapperTest
 {
+    public static final long ID = 1L;
+    public static final int INDEX = 1;
     private MutationSequenceMapper testInstance;
 
     @Mock
@@ -49,14 +50,13 @@ class MutationSequenceMapperTest
     void toEntity()
     {
         MutationSequenceDTO mutationSequenceDTO = new MutationSequenceDTO();
-        mutationSequenceDTO.setId(1L);
-        mutationSequenceDTO.setIndex(1);
+        mutationSequenceDTO.setId(ID);
+        mutationSequenceDTO.setIndex(INDEX);
         mutationSequenceDTO.setSequenceDTO(new SequenceDTO());
 
         MutationSequence mutationSequence = testInstance.toEntity(mutationSequenceDTO);
 
         verify(sequenceMapper, times(1)).toEntity(mutationSequenceDTO.getSequenceDTO());
-        assertThat(mutationSequence.getId(), is(1L));
-        assertThat(mutationSequence.getIndex(), is(1));
+        assertThat(mutationSequence.getIndex(), is(INDEX));
     }
 }

--- a/impc_prod_tracker/rest-api/src/test/java/org/gentar/biology/sequence/SequenceLocationMapperTest.java
+++ b/impc_prod_tracker/rest-api/src/test/java/org/gentar/biology/sequence/SequenceLocationMapperTest.java
@@ -1,0 +1,73 @@
+package org.gentar.biology.sequence;
+
+import org.gentar.biology.location.Location;
+import org.gentar.biology.location.LocationDTO;
+import org.gentar.biology.location.LocationMapper;
+import org.gentar.biology.sequence_location.SequenceLocation;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class SequenceLocationMapperTest
+{
+    public static final long ID = 1L;
+    public static final int INDEX = 1;
+    private SequenceLocationMapper testInstance;
+
+    @Mock
+    private LocationMapper locationMapper;
+
+    @BeforeEach
+    void setUp()
+    {
+        testInstance = new SequenceLocationMapper(locationMapper);
+    }
+
+    @Test
+    void toDto()
+    {
+        SequenceLocation sequenceLocation = new SequenceLocation();
+        sequenceLocation.setId(ID);
+        sequenceLocation.setIndex(INDEX);
+        Sequence sequence = new Sequence();
+        sequenceLocation.setSequence(sequence);
+        Location location = new Location();
+        sequenceLocation.setLocation(location);
+
+        LocationDTO mockLocationDto = new LocationDTO();
+
+        when(locationMapper.toDto(location)).thenReturn(mockLocationDto);
+
+        SequenceLocationDTO sequenceLocationDTO = testInstance.toDto(sequenceLocation);
+
+        assertThat(sequenceLocationDTO.getId(), is(ID));
+        assertThat(sequenceLocationDTO.getLocationIndex(), is(INDEX));
+        assertThat(sequenceLocationDTO.getLocationDTO(), is(mockLocationDto));
+    }
+
+    @Test
+    void toEntity()
+    {
+        SequenceLocationDTO sequenceLocationDTO = new SequenceLocationDTO();
+        sequenceLocationDTO.setId(null);
+        sequenceLocationDTO.setLocationIndex(INDEX);
+        LocationDTO locationDTO = new LocationDTO();
+        sequenceLocationDTO.setLocationDTO(locationDTO);
+
+        SequenceLocation sequenceLocation = testInstance.toEntity(sequenceLocationDTO);
+
+        assertThat(sequenceLocation.getId(), is(nullValue()));
+        assertThat(sequenceLocation.getIndex(), is(INDEX));
+        verify(locationMapper, times(1)).toEntity(locationDTO);
+    }
+}

--- a/impc_prod_tracker/rest-api/src/test/java/org/gentar/biology/sequence/SequenceMapperTest.java
+++ b/impc_prod_tracker/rest-api/src/test/java/org/gentar/biology/sequence/SequenceMapperTest.java
@@ -10,6 +10,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.ArrayList;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -17,6 +18,7 @@ import static org.mockito.Mockito.verify;
 @ExtendWith(MockitoExtension.class)
 class SequenceMapperTest
 {
+    public static final Long ID = 1L;
     public static final String SEQUENCE = "CGAGTGA";
     public static final String SEQUENCE_CATEGORY_NAME = "sequenceCategoryName";
     public static final String SEQUENCE_TYPE_NAME = "sequenceTypeName";
@@ -61,6 +63,7 @@ class SequenceMapperTest
     void toEntity()
     {
         SequenceDTO sequenceDTO = new SequenceDTO();
+        sequenceDTO.setId(null);
         sequenceDTO.setSequence(SEQUENCE);
         sequenceDTO.setSequenceCategoryName(SEQUENCE_CATEGORY_NAME);
         sequenceDTO.setSequenceTypeName(SEQUENCE_TYPE_NAME);
@@ -68,6 +71,7 @@ class SequenceMapperTest
 
         Sequence sequence = testInstance.toEntity(sequenceDTO);
 
+        assertThat(sequence.getId(), is(nullValue()));
         assertThat(sequence.getSequence(), is(SEQUENCE));
         verify(sequenceCategoryMapper, times(1)).toEntity(SEQUENCE_CATEGORY_NAME);
         verify(sequenceTypeMapper, times(1)).toEntity(SEQUENCE_TYPE_NAME);


### PR DESCRIPTION
- Fix several problems when updating mutations.
- Reducir length of the objects graph to analyse by using the annotation to ignore fields to audit.
- Deleting commented code.
- Setting property spring.jpa.properties.hibernate.event.merge.entity_copy_observer=log to avoid "InvalidDataAccessApiUsageException: Multiple representations of the same entity" error.