### PR TITLE
Reversing Eager fetch in WorkInit for consortia and workGroups

### DIFF
--- a/impc_prod_tracker/core/src/main/java/org/gentar/organization/work_unit/WorkUnit.java
+++ b/impc_prod_tracker/core/src/main/java/org/gentar/organization/work_unit/WorkUnit.java
@@ -46,13 +46,13 @@ public class WorkUnit extends BaseEntity
     @ToString.Exclude
     @JsonIgnore
     @IgnoreForAuditingChanges
-    @ManyToMany(fetch=FetchType.EAGER, mappedBy = "workUnits")
+    @ManyToMany(mappedBy = "workUnits")
     private Set<Consortium> consortia;
 
     @EqualsAndHashCode.Exclude
     @ToString.Exclude
     @IgnoreForAuditingChanges
-    @ManyToMany(fetch=FetchType.EAGER, mappedBy = "workUnits")
+    @ManyToMany(mappedBy = "workUnits")
     private Set<WorkGroup> workGroups;
 
     public WorkUnit(String name)


### PR DESCRIPTION
- The LazyInitiationException is not being thrown anymore when running the tests. Removing the eager annotation because it increases the execution time and it was meant to fix the exception that is not already present.