### PR TITLE
Fix error when updating phenotyping attempt

### DIFF
--- a/impc_prod_tracker/core/src/main/java/org/gentar/biology/plan/attempt/phenotyping/PhenotypingAttempt.java
+++ b/impc_prod_tracker/core/src/main/java/org/gentar/biology/plan/attempt/phenotyping/PhenotypingAttempt.java
@@ -6,11 +6,13 @@ import org.gentar.audit.diff.IgnoreForAuditingChanges;
 import org.gentar.biology.plan.Plan;
 import org.gentar.biology.plan.attempt.phenotyping.stage.PhenotypingStage;
 import org.gentar.biology.strain.Strain;
+
 import javax.persistence.*;
 import javax.validation.constraints.NotNull;
+import java.util.HashSet;
 import java.util.Set;
 
-@NoArgsConstructor(access= AccessLevel.PUBLIC, force=true)
+@NoArgsConstructor(access = AccessLevel.PUBLIC, force = true)
 @Data
 @Entity
 public class PhenotypingAttempt extends BaseEntity
@@ -35,11 +37,27 @@ public class PhenotypingAttempt extends BaseEntity
     private String phenotypingExternalRef;
 
     @NotNull
-    @ManyToOne(cascade=CascadeType.ALL)
+    @ManyToOne(cascade = CascadeType.ALL)
     private Strain strain;
 
     @ToString.Exclude
     @EqualsAndHashCode.Exclude
     @OneToMany(cascade = CascadeType.ALL, mappedBy = "phenotypingAttempt")
     private Set<PhenotypingStage> phenotypingStages;
+
+    // Copy Constructor
+    public PhenotypingAttempt(PhenotypingAttempt phenotypingAttempt)
+    {
+        this.id = phenotypingAttempt.id;
+        this.plan = phenotypingAttempt.plan;
+        this.imitsPhenotypeAttempt = phenotypingAttempt.imitsPhenotypeAttempt;
+        this.imitsPhenotypingProduction = phenotypingAttempt.imitsPhenotypingProduction;
+        this.imitsParentColony = phenotypingAttempt.imitsParentColony;
+        this.doNotCountTowardsCompleteness = phenotypingAttempt.doNotCountTowardsCompleteness;
+        this.phenotypingExternalRef = phenotypingAttempt.phenotypingExternalRef;
+        this.strain = phenotypingAttempt.strain;
+        this.phenotypingStages =
+            phenotypingAttempt.phenotypingStages == null ? null :
+                new HashSet<>(phenotypingAttempt.phenotypingStages);
+    }
 }

--- a/impc_prod_tracker/rest-api/src/main/java/org/gentar/biology/plan/UpdatePlanRequestProcessor.java
+++ b/impc_prod_tracker/rest-api/src/main/java/org/gentar/biology/plan/UpdatePlanRequestProcessor.java
@@ -15,6 +15,7 @@
  */
 package org.gentar.biology.plan;
 
+import org.gentar.biology.plan.attempt.phenotyping.PhenotypingAttempt;
 import org.gentar.biology.plan.mappers.PlanUpdateMapper;
 import org.gentar.statemachine.ProcessEvent;
 import org.springframework.stereotype.Component;
@@ -26,8 +27,8 @@ import org.springframework.stereotype.Component;
 @Component
 public class UpdatePlanRequestProcessor
 {
-    private PlanUpdateMapper planUpdateMapper;
-    private PlanService planService;
+    private final PlanUpdateMapper planUpdateMapper;
+    private final PlanService planService;
 
     public UpdatePlanRequestProcessor(PlanUpdateMapper planUpdateMapper, PlanService planService)
     {
@@ -52,14 +53,8 @@ public class UpdatePlanRequestProcessor
             Plan mappedPlan = planUpdateMapper.toEntity(planUpdateDTO);
             plan.setComment(mappedPlan.getComment());
             plan.setProductsAvailableForGeneralPublic(mappedPlan.getProductsAvailableForGeneralPublic());
-            if (mappedPlan.getCrisprAttempt() != null)
-            {
-                plan.setCrisprAttempt(mappedPlan.getCrisprAttempt());
-            }
-            if (mappedPlan.getPhenotypingAttempt() != null)
-            {
-                plan.setPhenotypingAttempt(mappedPlan.getPhenotypingAttempt());
-            }
+            setUpdatedCrisprAttempt(plan, mappedPlan);
+            setUpdatedPhenotypingAttempt(plan, mappedPlan);
             if (mappedPlan.getBreedingAttempt() != null)
             {
                 plan.setBreedingAttempt(mappedPlan.getBreedingAttempt());
@@ -67,6 +62,31 @@ public class UpdatePlanRequestProcessor
             setEvent(plan, planUpdateDTO);
         }
         return plan;
+    }
+
+    private void setUpdatedCrisprAttempt(Plan originalPlan, Plan mappedPlan)
+    {
+        if (mappedPlan.getCrisprAttempt() != null)
+        {
+            originalPlan.setCrisprAttempt(mappedPlan.getCrisprAttempt());
+        }
+    }
+
+    // Update only desired fields
+    private void setUpdatedPhenotypingAttempt(Plan originalPlan, Plan mappedPlan)
+    {
+        if (mappedPlan.getPhenotypingAttempt() != null)
+        {
+            PhenotypingAttempt phenotypingAttempt =
+                new PhenotypingAttempt(originalPlan.getPhenotypingAttempt());
+            PhenotypingAttempt mmapedPhenotypingAttempt = mappedPlan.getPhenotypingAttempt();
+            phenotypingAttempt.setDoNotCountTowardsCompleteness(
+                mmapedPhenotypingAttempt.getDoNotCountTowardsCompleteness());
+            phenotypingAttempt.setPhenotypingExternalRef(
+                mmapedPhenotypingAttempt.getPhenotypingExternalRef());
+            phenotypingAttempt.setStrain(mmapedPhenotypingAttempt.getStrain());
+            originalPlan.setPhenotypingAttempt(phenotypingAttempt);
+        }
     }
 
     private void setEvent(Plan plan, PlanUpdateDTO planUpdateDTO)


### PR DESCRIPTION
- Because the updated object was taking directly the mapped DTO, the previous values that were not there were lost