### PR TITLE
Remove duplicated entry for field documentation of "genomicEndCoordinate"

### DIFF
--- a/impc_prod_tracker/rest-api/src/test/java/org/gentar/biology/plan/PlanFieldsDescriptors.java
+++ b/impc_prod_tracker/rest-api/src/test/java/org/gentar/biology/plan/PlanFieldsDescriptors.java
@@ -178,10 +178,6 @@ public class PlanFieldsDescriptors
             "crisprAttempt.genotypePrimers[].genomicEndCoordinate",
             "Genomic end coordinate.");
         addField(
-            crisprFields,
-            "crisprAttempt.genotypePrimers[].genomicEndCoordinate",
-            "Genotype primer name.");
-        addField(
             crisprFields, "crisprAttempt.genotypePrimers[].sequence", "Genotype primer sequence.");
 
         // Assay


### PR DESCRIPTION
Remove duplicated entry for field documentation of "genomicEndCoordinate".