### PR TITLE
Moving logic to check if tissue distribution needs to be created automatically

### DIFF
--- a/impc_prod_tracker/core/src/main/java/org/gentar/biology/plan/attempt/phenotyping/stage/engine/processors/PhenotypingStartedProcessorWithTissueCreation.java
+++ b/impc_prod_tracker/core/src/main/java/org/gentar/biology/plan/attempt/phenotyping/stage/engine/processors/PhenotypingStartedProcessorWithTissueCreation.java
@@ -6,6 +6,7 @@ import org.gentar.biology.plan.attempt.phenotyping.stage.material_deposited_type
 import org.gentar.biology.plan.attempt.phenotyping.stage.material_deposited_type.MaterialDepositedTypeNames;
 import org.gentar.biology.plan.attempt.phenotyping.stage.material_deposited_type.MaterialDepositedTypeService;
 import org.gentar.biology.plan.attempt.phenotyping.stage.tissue_distribution.TissueDistribution;
+import org.gentar.organization.work_unit.WorkUnit;
 import org.gentar.security.abac.spring.ContextAwarePolicyEnforcement;
 import org.gentar.security.permissions.Actions;
 import org.gentar.statemachine.AbstractProcessor;
@@ -15,6 +16,7 @@ import org.gentar.statemachine.TransitionEvaluation;
 import org.springframework.stereotype.Component;
 import java.time.LocalDate;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -30,6 +32,7 @@ public class PhenotypingStartedProcessorWithTissueCreation extends AbstractProce
 {
     private final ContextAwarePolicyEnforcement policyEnforcement;
     private final MaterialDepositedTypeService materialDepositedTypeService;
+    private final static List<String> WORK_UNIT_NAMES_AUTOMATIC_TISSUE_DISTRIBUTION = Arrays.asList("UCD");
 
     public PhenotypingStartedProcessorWithTissueCreation(
         PhenotypingStageStateSetter phenotypingStageStateSetter,
@@ -129,7 +132,7 @@ public class PhenotypingStartedProcessorWithTissueCreation extends AbstractProce
 
     private boolean needToCreateTissueDistribution(PhenotypingStage phenotypingStage)
     {
-        return policyEnforcement.hasPermission(
-            phenotypingStage, Actions.AUTOMATIC_TISSUE_DISTRIBUTION_CREATION);
+        WorkUnit workUnit = phenotypingStage.getPhenotypingAttempt().getPlan().getWorkUnit();
+        return WORK_UNIT_NAMES_AUTOMATIC_TISSUE_DISTRIBUTION.contains(workUnit.getName());
     }
 }

--- a/impc_prod_tracker/core/src/main/java/org/gentar/security/permissions/Actions.java
+++ b/impc_prod_tracker/core/src/main/java/org/gentar/security/permissions/Actions.java
@@ -13,5 +13,4 @@ public class Actions
     public static final String UPDATE_USER = "UPDATE_USER";
     public static final String MANAGE_GENE_LIST_ACTION = "MANAGE_GENE_LISTS";
     public static final String UPDATE_TO_PHENOTYPING_STARTED = "UPDATE_TO_PHENOTYPING_STARTED";
-    public static final String AUTOMATIC_TISSUE_DISTRIBUTION_CREATION = "AUTOMATIC_TISSUE_DISTRIBUTION_CREATION";
 }

--- a/impc_prod_tracker/core/src/main/resources/org/gentar/security/abac/policy/json/default-policy.json
+++ b/impc_prod_tracker/core/src/main/resources/org/gentar/security/abac/policy/json/default-policy.json
@@ -192,12 +192,5 @@
     "description": "DCC or CDA can update a phenotyping stage from Phenotyping Finished to All Data Processed",
     "target": "action == 'REVERSE_FROM_PHENOTYPING_FINISHED_TO_ALL_DATA_PROCESSED'",
     "condition": "subject.isUserByKey('cda_user_key') OR subject.isUserByKey('dcc_user_key')"
-  },
-
-  {
-    "name": "Automatically create tissue distribution when moving from Phenotyping Registered to Phenotyping Started",
-    "description": "For some work units the transition should create a 'Fixed Tissue' tissue distribution",
-    "target": "action == 'AUTOMATIC_TISSUE_DISTRIBUTION_CREATION'",
-    "condition": "{'UCD'}.contains(resource.workUnit.name)"
   }
 ]

--- a/impc_prod_tracker/core/src/test/java/org/gentar/biology/plan/attempt/phenotyping/stage/engine/processors/PhenotypingStartedProcessorWithTissueCreationTest.java
+++ b/impc_prod_tracker/core/src/test/java/org/gentar/biology/plan/attempt/phenotyping/stage/engine/processors/PhenotypingStartedProcessorWithTissueCreationTest.java
@@ -51,7 +51,7 @@ class PhenotypingStartedProcessorWithTissueCreationTest
     private final MaterialDepositedType fixedMaterialDepositedType = new MaterialDepositedType();
     private MaterialDepositedType paraffinMaterialDepositedType;
 
-    private static final String AUTOMATIC_TISSUE_CREATION_WORK_UNIT = "USC";
+    private static final String AUTOMATIC_TISSUE_CREATION_WORK_UNIT = "UCD";
     private static final String NOT_AUTOMATIC_TISSUE_CREATION_WORK_UNIT = "JAX";
 
     @BeforeEach
@@ -72,8 +72,6 @@ class PhenotypingStartedProcessorWithTissueCreationTest
             AUTOMATIC_TISSUE_CREATION_WORK_UNIT);
         phenotypingStage.setEvent(PhenotypingStageEvent.updateToPhenotypingStarted);
         when(policyEnforcement.hasPermission(null, Actions.UPDATE_TO_PHENOTYPING_STARTED)).thenReturn(true);
-        when(policyEnforcement.hasPermission(
-            phenotypingStage, Actions.AUTOMATIC_TISSUE_DISTRIBUTION_CREATION)).thenReturn(true);
         when(materialDepositedTypeService.getMaterialDepositedTypeByName(FIXED_TISSUE_NAME))
             .thenReturn(fixedMaterialDepositedType);
         testInstance.process(phenotypingStage);
@@ -110,8 +108,6 @@ class PhenotypingStartedProcessorWithTissueCreationTest
         phenotypingStage.addTissueDistribution(existingTissueDistribution);
         phenotypingStage.setEvent(PhenotypingStageEvent.updateToPhenotypingStarted);
         when(policyEnforcement.hasPermission(null, Actions.UPDATE_TO_PHENOTYPING_STARTED)).thenReturn(true);
-        when(policyEnforcement.hasPermission(
-            phenotypingStage, Actions.AUTOMATIC_TISSUE_DISTRIBUTION_CREATION)).thenReturn(true);
         testInstance.process(phenotypingStage);
 
         assertThat(
@@ -138,8 +134,6 @@ class PhenotypingStartedProcessorWithTissueCreationTest
             NOT_AUTOMATIC_TISSUE_CREATION_WORK_UNIT);
         phenotypingStage.setEvent(PhenotypingStageEvent.updateToPhenotypingStarted);
         when(policyEnforcement.hasPermission(null, Actions.UPDATE_TO_PHENOTYPING_STARTED)).thenReturn(true);
-        when(policyEnforcement.hasPermission(
-            phenotypingStage, Actions.AUTOMATIC_TISSUE_DISTRIBUTION_CREATION)).thenReturn(false);
 
         testInstance.process(phenotypingStage);
 
@@ -164,8 +158,6 @@ class PhenotypingStartedProcessorWithTissueCreationTest
         phenotypingStage.addTissueDistribution(existingTissueDistribution);
         phenotypingStage.setEvent(PhenotypingStageEvent.updateToPhenotypingStarted);
         when(policyEnforcement.hasPermission(null, Actions.UPDATE_TO_PHENOTYPING_STARTED)).thenReturn(true);
-        when(policyEnforcement.hasPermission(
-            phenotypingStage, Actions.AUTOMATIC_TISSUE_DISTRIBUTION_CREATION)).thenReturn(false);
 
         testInstance.process(phenotypingStage);
 


### PR DESCRIPTION
Moving logic to check if tissue distribution needs to be created automatically

- Move logic from ABAC rules set to specific processor in the phenotyping stage stage machine.