### PR TITLE
<BUGFIX>: ProjectQueryHelper update

### DIFF
--- a/impc_prod_tracker/core/src/main/java/org/gentar/biology/project/ProjectQueryHelper.java
+++ b/impc_prod_tracker/core/src/main/java/org/gentar/biology/project/ProjectQueryHelper.java
@@ -89,7 +89,7 @@ public class ProjectQueryHelper
     public Set<String> getWorkGroupsNames(Project project)
     {
         Set<String> workGroupsNames = new HashSet<>();
-        project.getRelatedWorkUnits().forEach(x -> workGroupsNames.add(x.getName()));
+        project.getRelatedWorkGroups().forEach(x -> workGroupsNames.add(x.getName()));
         return workGroupsNames;
     }
 


### PR DESCRIPTION
ProjectQueryHelper getWorkGroupsNames method updated to provide workGroupNames rather than workUnitNames. This fixed an issue with data download.